### PR TITLE
Update supportedChains.tsx with Arbitrum Goerli

### DIFF
--- a/packages/connectkit/src/constants/supportedChains.tsx
+++ b/packages/connectkit/src/constants/supportedChains.tsx
@@ -68,6 +68,11 @@ const supportedChains: Chain[] = [
     name: 'Arbitrum Rinkeby',
     logo: <Logos.Arbitrum testnet />,
   },
+  {
+    id: 421613,
+    name: 'Arbitrum Goerli',
+    logo: <Logos.Arbitrum testnet />,
+  },
 ];
 
 export default supportedChains;


### PR DESCRIPTION
Arbitrum Rinkeby is deprecated now and marked as read-only. Adding in icon resolution support for the new testnet.