### PR TITLE
Fix unknown chain logo

### DIFF
--- a/packages/connectkit/src/components/Common/Chain/index.tsx
+++ b/packages/connectkit/src/components/Common/Chain/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ChainContainer, LoadingContainer } from './styles';
 import { motion, AnimatePresence } from 'framer-motion';
 import supportedChains from '../../../constants/supportedChains';
+import Logos from '../../../assets/chains';
 
 const Spinner = (
   <svg
@@ -62,7 +63,7 @@ const Chain: React.FC<{
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
           >
-            {chain?.logo}
+            {chain?.logo || <Logos.UnknownChain />}
           </motion.div>
         ) : (
           <LoadingContainer

--- a/packages/connectkit/src/components/Common/ChainSelect/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelect/index.tsx
@@ -14,6 +14,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import Tooltip from '../Tooltip';
 import ChainSelectDropdown from '../ChainSelectDropdown';
 
+import Logos from '../../../assets/chains';
+
 const Container = styled(motion.div)``;
 
 const SwitchChainButton = styled(motion.button)`
@@ -191,7 +193,7 @@ const ChainSelector: React.FC = () => {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2 }}
               >
-                {c?.logo}
+                {c?.logo || <Logos.UnknownChain />}
               </motion.div>
             );
           })}


### PR DESCRIPTION
I noticed if the Wagmi configuration has chains not included in the default supported chains list, the "Unknown Chain" logo only appears in the chain select dropdown and not in the ConnectKitModal or ConnectKitButton components. Very easy fix. Thanks for creating such a beautiful project! 