### PR TITLE
fix: downgrade react types to fix nextjs builds

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -18,8 +18,8 @@
   },
   "devDependencies": {
     "@types/node": "18.7.18",
-    "@types/react": "18.0.20",
-    "@types/react-dom": "18.0.6",
+    "@types/react": "^18.0.6",
+    "@types/react-dom": "^18.0.2",
     "eslint": "8.23.1",
     "eslint-config-next": "12.3.0",
     "typescript": "4.8.3"

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -18,8 +18,8 @@
   },
   "devDependencies": {
     "@types/node": "18.7.18",
-    "@types/react": "18.0.20",
-    "@types/react-dom": "18.0.6",
+    "@types/react": "^18.0.6",
+    "@types/react-dom": "^18.0.2",
     "eslint": "8.23.1",
     "eslint-config-next": "12.3.0",
     "typescript": "4.8.3"


### PR DESCRIPTION
issue with react types, downgraded to fix
was causing wagmi not the be recognised (`Uncaught TypeError: Cannot read property 'mainnet' of undefined`)