### PR TITLE
use NEXT_PUBLIC_ to expose SESSION_SECRET

### DIFF
--- a/packages/connectkit-next-siwe/src/configureSIWE.tsx
+++ b/packages/connectkit-next-siwe/src/configureSIWE.tsx
@@ -142,7 +142,7 @@ export const configureSIWE = <TSessionData extends Object = {}>({
 }: NextSIWEConfig): ConfigureSIWEResult<TSessionData> => {
   const sessionConfig: IronSessionOptions = {
     cookieName: cookieName ?? 'connectkit-next-siwe',
-    password: password ?? envVar('SESSION_SECRET'),
+    password: password ?? envVar('NEXT_PUBLIC_SESSION_SECRET'),
     cookieOptions: {
       secure: process.env.NODE_ENV === 'production',
       ...(cookieOptions ?? {}),


### PR DESCRIPTION
In this PR I changed the default environment variable for the session password of the iron-session options.

Previously it was set to `SESSION_SECRET` causing an error on the front end.

<img width="1192" alt="Screenshot 2022-11-09 at 9 05 25 AM" src="https://user-images.githubusercontent.com/57334399/200847502-50a1cfeb-cbb7-4bf7-a687-f06284265993.png">

To fix this issue I added the `NEXT_PUBLIC_` prefix required to [expose environment variables](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser) to the browser. 

Note: I'm not knowledgeable about iron-session, but should this `SESSION_SECRET` be exposed to the client?

Also, the [connectkit documentation](https://docs.family.co/connectkit/auth-with-nextjs#siwe-nextjs-implementation-2-configure) is a little confusing. It says:

> You'll also want to set up an environment variable called 
SESSION_SECRET

This should be changed to:

> You'll also want to set up an environment variable called 
NEXT_PUBLIC_SESSION_SECRET

Assuming that the correct implementation requires this secret to be exposed to the client.
