### PR TITLE
fix: dead links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Remove sunset ethhub.io links and replace with ethereum.org links.
+- New options for `ethereumOnboardingUrl` and `walletOnboardingUrl` to custom change the _Learn More_ and _About Wallets_ call to actions.
+
 # 1.1.1
 
 This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`0.9.x`).

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -75,6 +75,8 @@ type ConnectKitOptions = {
   bufferPolyfill?: boolean;
   customAvatar?: React.FC<CustomAvatarProps>;
   initialChainId?: number;
+  ethereumOnboardingUrl?: string;
+  walletOnboardingUrl?: string;
 };
 
 type ConnectKitProviderProps = {
@@ -116,6 +118,8 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     bufferPolyfill: true,
     customAvatar: undefined,
     initialChainId: undefined,
+    ethereumOnboardingUrl: undefined,
+    walletOnboardingUrl: undefined,
   };
 
   const opts: ConnectKitOptions = Object.assign({}, defaultOptions, options);

--- a/packages/connectkit/src/components/Pages/About/index.tsx
+++ b/packages/connectkit/src/components/Pages/About/index.tsx
@@ -32,6 +32,9 @@ const About: React.FC = () => {
   });
   const context = useContext();
 
+  const ctaUrl =
+    context.options?.ethereumOnboardingUrl ?? locales.aboutScreen_ctaUrl;
+
   const [ready, setReady] = useState(true);
   const [slider, setSlider] = useState(0);
   const interacted = useRef(false);
@@ -254,7 +257,7 @@ const About: React.FC = () => {
           ))}
         </Dots>
       </OrDivider>
-      <Button href={locales.aboutScreen_ctaUrl} arrow>
+      <Button href={ctaUrl} arrow>
         {locales.aboutScreen_ctaText}
       </Button>
     </PageContent>

--- a/packages/connectkit/src/components/Pages/Onboarding/index.tsx
+++ b/packages/connectkit/src/components/Pages/Onboarding/index.tsx
@@ -22,9 +22,14 @@ import wave from '../../../assets/wave';
 
 import Button from '../../Common/Button';
 import useLocales from '../../../hooks/useLocales';
+import { useContext } from '../../ConnectKit';
 
 const Introduction: React.FC = () => {
+  const context = useContext();
   const locales = useLocales({});
+
+  const ctaUrl =
+    context.options?.walletOnboardingUrl ?? locales.onboardingScreen_ctaUrl;
   return (
     <PageContent>
       <Graphic>
@@ -101,7 +106,7 @@ const Introduction: React.FC = () => {
         <ModalH1 $small>{locales.onboardingScreen_h1}</ModalH1>
         <ModalBody>{locales.onboardingScreen_p}</ModalBody>
       </ModalContent>
-      <Button href={locales.onboardingScreen_ctaUrl} arrow>
+      <Button href={ctaUrl} arrow>
         {locales.onboardingScreen_ctaText}
       </Button>
     </PageContent>

--- a/packages/connectkit/src/localizations/locales/en-US.ts
+++ b/packages/connectkit/src/localizations/locales/en-US.ts
@@ -43,7 +43,7 @@ const enUS: LocaleProps = {
   onboardingScreen_h1: `Start Exploring Web3`,
   onboardingScreen_p: `Your wallet is the gateway to all things Ethereum, the magical technology that makes it possible to explore web3.`,
   onboardingScreen_ctaText: `Choose Your First Wallet`,
-  onboardingScreen_ctaUrl: `https://ethereum.org/en/wallets/find-wallet/#main-content`,
+  onboardingScreen_ctaUrl: `https://ethereum.org/en/wallets/find-wallet/`,
 
   aboutScreen_heading: `About Wallets`,
   aboutScreen_a_h1: `For your digital assets`,
@@ -53,7 +53,7 @@ const enUS: LocaleProps = {
   aboutScreen_c_h1: `Explore the world of web3`,
   aboutScreen_c_p: `Your wallet is an essential utility that lets you explore and participate in the fast evolving world of web3.`,
   aboutScreen_ctaText: `Learn More`,
-  aboutScreen_ctaUrl: `https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets/`,
+  aboutScreen_ctaUrl: `https://ethereum.org/en/wallets/`,
 
   connectorsScreen_heading: `Connect Wallet`,
   connectorsScreen_newcomer: `I don’t have a wallet`,

--- a/packages/connectkit/src/localizations/locales/es-ES.ts
+++ b/packages/connectkit/src/localizations/locales/es-ES.ts
@@ -43,7 +43,7 @@ const esES: LocaleProps = {
   onboardingScreen_h1: `Comienza a explorar la Web3`,
   onboardingScreen_p: `Tu cartera es el portal de acceso a todo lo relacionado con Ethereum, la tecnología mágica que permite explorar la Web3.`,
   onboardingScreen_ctaText: `Elige tu primera cartera`,
-  onboardingScreen_ctaUrl: `https://ethereum.org/es/wallets/find-wallet/#main-content`,
+  onboardingScreen_ctaUrl: `https://ethereum.org/es/wallets/find-wallet/`,
 
   aboutScreen_heading: `Acerca de las carteras`,
   aboutScreen_a_h1: `Para tus activos digitales`,
@@ -53,7 +53,7 @@ const esES: LocaleProps = {
   aboutScreen_c_h1: `Explora el mundo de la Web3`,
   aboutScreen_c_p: `Tu cartera es una herramienta esencial que te permite explorar y participar en el mundo en rápida evolución de la Web3.`,
   aboutScreen_ctaText: `Más información`,
-  aboutScreen_ctaUrl: `https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets/`, // TODO: Replace when version is available.
+  aboutScreen_ctaUrl: `https://ethereum.org/es/wallets/`,
 
   connectorsScreen_heading: `Conecta una cartera`,
   connectorsScreen_newcomer: `No tengo una cartera`,

--- a/packages/connectkit/src/localizations/locales/fr-FR.ts
+++ b/packages/connectkit/src/localizations/locales/fr-FR.ts
@@ -43,7 +43,7 @@ const frFR: LocaleProps = {
   onboardingScreen_h1: `Commencez à explorer le Web3`,
   onboardingScreen_p: `Votre portefeuille est la porte d'entrée vers tout ce qui concerne l'Ethereum, la technologie magique qui permet d'explorer le Web3.`,
   onboardingScreen_ctaText: `Choisissez votre premier portefeuille`,
-  onboardingScreen_ctaUrl: `https://ethereum.org/fr/wallets/find-wallet/#main-content`,
+  onboardingScreen_ctaUrl: `https://ethereum.org/fr/wallets/find-wallet/`,
 
   aboutScreen_heading: `À propos des portefeuilles`,
   aboutScreen_a_h1: `Pour vos actifs numériques`,
@@ -53,7 +53,7 @@ const frFR: LocaleProps = {
   aboutScreen_c_h1: `Explorez le monde du Web3`,
   aboutScreen_c_p: `Votre portefeuille est un utilitaire essentiel qui vous permet d'explorer et de participer au monde en évolution rapide du Web3.`,
   aboutScreen_ctaText: `En savoir plus`,
-  aboutScreen_ctaUrl: `https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets/`, // TODO: Replace when version is available.
+  aboutScreen_ctaUrl: `https://ethereum.org/fr/wallets/`,
 
   connectorsScreen_heading: `Connectez le portefeuille`,
   connectorsScreen_newcomer: `Je n’ai pas de portefeuille`,

--- a/packages/connectkit/src/localizations/locales/ja-JP.ts
+++ b/packages/connectkit/src/localizations/locales/ja-JP.ts
@@ -41,7 +41,7 @@ export default {
   onboardingScreen_h1: `Web3 の探索を開始`,
   onboardingScreen_p: `ウォレットは、web3 の探索を可能にする魔法のテクノロジーであるイーサリアムのすべてへのゲートウェイです。`,
   onboardingScreen_ctaText: `最初のウォレットを選択してください`,
-  onboardingScreen_ctaUrl: `https://ethereum.org/ja/wallets/find-wallet/#main-content`,
+  onboardingScreen_ctaUrl: `https://ethereum.org/ja/wallets/find-wallet/`,
 
   aboutScreen_heading: `ウォレットについて`,
   aboutScreen_a_h1: `デジタル資産用`,
@@ -51,7 +51,7 @@ export default {
   aboutScreen_c_h1: `web3 の世界を探索`,
   aboutScreen_c_p: `ウォレットは、急速に進化する web3 の世界を探索し、参加するために不可欠なユーティリティです。`,
   aboutScreen_ctaText: `詳細情報`,
-  aboutScreen_ctaUrl: `https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets/`, // TODO: Replace when version is available.
+  aboutScreen_ctaUrl: `https://ethereum.org/ja/wallets/`,
 
   connectorsScreen_heading: `ウォレットの接続`,
   connectorsScreen_newcomer: `ウォレットを持っていません`,

--- a/packages/connectkit/src/localizations/locales/zh-CN.ts
+++ b/packages/connectkit/src/localizations/locales/zh-CN.ts
@@ -43,7 +43,7 @@ const zhCN: LocaleProps = {
   onboardingScreen_h1: `开始探索 Web3`,
   onboardingScreen_p: `您的钱包是通往以太坊的一扇大门，而以太坊是探索 Web3 的一项神奇技术。`,
   onboardingScreen_ctaText: `选择您的第一钱包`,
-  onboardingScreen_ctaUrl: `https://ethereum.org/zh/wallets/find-wallet/#main-content`,
+  onboardingScreen_ctaUrl: `https://ethereum.org/zh/wallets/find-wallet/`,
 
   aboutScreen_heading: `关于钱包`,
   aboutScreen_a_h1: `对于您的数字资产`,
@@ -53,7 +53,7 @@ const zhCN: LocaleProps = {
   aboutScreen_c_h1: `探索 Web3 世界`,
   aboutScreen_c_p: `您的钱包是一个重要的工具，可以让您探索并参与到快速发展的 Web3 世界。`,
   aboutScreen_ctaText: `了解更多`,
-  aboutScreen_ctaUrl: `https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets/`, // TODO: Replace when version is available. There is https://zh.docs.ethhub.io/ but there is currently no intro-to-ethereum-wallets page
+  aboutScreen_ctaUrl: `https://ethereum.org/zh/wallets/`,
 
   connectorsScreen_heading: `绑定钱包`,
   connectorsScreen_newcomer: `我没有钱包`,


### PR DESCRIPTION
**Fixes: https://github.com/family/connectkit/issues/75**

- Removes [sunset ethhub.io](https://twitter.com/econoar/status/1600932091398529024) link (https://docs.ethhub.io/using-ethereum/wallets/intro-to-ethereum-wallets) and replaces with ethereum.org's wallet onboarding page (https://ethereum.org/en/wallets/).
- Gives developers the option to replace external links within the `ConnectKitProvider` options under `options.walletOnboardingUrl` and `options.ethereumOnboardingUrl`.