### PR TITLE
update: better configured chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+#
+
+## New
+
+- Update to allow turning off the default targeted `chainId` to let wallets connect using their currently active chain.
+- - This can be done by setting `initialChainId` to `0` within the `getDefaultClient` helper function.
+- Update to chain handling to allow devs access to the configured chains using `getGlobalChains`.
+
+## Removed
+
+- Removed CommonJS support to work within wagmi's `0.8.x` requirements.
+
 # 1.1.1
 
 This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`0.9.x`).

--- a/examples/testbench/src/TestbenchProvider.tsx
+++ b/examples/testbench/src/TestbenchProvider.tsx
@@ -50,6 +50,7 @@ export const TestBenchProvider: React.FC<TestBenchProviderProps> = ({
     disclaimer: null,
     bufferPolyfill: true,
     walletConnectCTA: 'modal',
+    //initialChainId: 0,
   },
 }) => {
   const [ckCustomTheme, setCustomTheme] = useState<Types.Theme>(customTheme);

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -6,6 +6,7 @@ import {
   useSIWE,
   SIWEButton,
   ChainIcon,
+  getGlobalChains,
 } from 'connectkit';
 import { useTestBench } from '../TestbenchProvider';
 import { Checkbox, Textbox, Select, SelectProps } from '../components/inputs';
@@ -198,6 +199,7 @@ const Home: NextPage = () => {
   useEffect(() => setMounted(true), []);
 
   const { chain } = useNetwork();
+  const chains = getGlobalChains();
 
   if (!mounted) return null;
 
@@ -233,6 +235,12 @@ const Home: NextPage = () => {
           <ChainIcon id={1} />
           <ChainIcon id={1337} />
           <ChainIcon id={2} unsupported />
+        </div>
+        <p>Supported Chains</p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {chains.map((chain) => (
+            <ChainIcon key={chain.id} id={chain.id} />
+          ))}
         </div>
       </main>
       <aside>

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -21,6 +21,7 @@ import { ThemeProvider } from 'styled-components';
 import { useThemeFont } from '../hooks/useGoogleFont';
 import { useAccount, useNetwork } from 'wagmi';
 import { SIWEContext } from './Standard/SIWE/SIWEContext';
+import { getGlobalChains } from '../defaultClient';
 
 export const routes = {
   ONBOARDING: 'onboarding',
@@ -115,7 +116,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     disclaimer: null,
     bufferPolyfill: true,
     customAvatar: undefined,
-    initialChainId: undefined,
+    initialChainId: getGlobalChains()[0]?.id,
   };
 
   const opts: ConnectKitOptions = Object.assign({}, defaultOptions, options);

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithInjector/index.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithInjector/index.tsx
@@ -10,7 +10,7 @@ import {
 } from './styles';
 
 import { useContext } from '../../ConnectKit';
-import { useConnect, useNetwork } from 'wagmi';
+import { useConnect } from 'wagmi';
 import supportedConnectors from '../../../constants/supportedConnectors';
 
 import {
@@ -80,7 +80,6 @@ const ConnectWithInjector: React.FC<{
 }> = ({ connectorId, switchConnectMethod, forceState }) => {
   const context = useContext();
 
-  const { chains } = useNetwork();
   const { connect, connectors } = useConnect({
     onMutate: (connector?: any) => {
       if (connector.connector) {
@@ -173,7 +172,7 @@ const ConnectWithInjector: React.FC<{
     if (con) {
       connect({
         connector: con,
-        chainId: context.options?.initialChainId ?? chains[0]?.id,
+        chainId: context.options?.initialChainId,
       });
     } else {
       setStatus(states.UNAVAILABLE);

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -9,9 +9,6 @@ import {
 
 import { PageContent, ModalContent } from '../../Common/Modal/styles';
 
-import Button from '../../Common/Button';
-
-import { ExternalLinkIcon } from '../../../assets/icons';
 import { useConnect } from '../../../hooks/useConnect';
 import useDefaultWallets from '../../../wallets/useDefaultWallets';
 import { routes, useContext } from '../../ConnectKit';
@@ -19,8 +16,8 @@ import { WalletProps } from '../../../wallets/wallet';
 import { useDefaultWalletConnect } from '../../../hooks/useDefaultWalletConnect';
 import CopyToClipboard from '../../Common/CopyToClipboard';
 import { walletConnect } from '../../../wallets/connectors/walletConnect';
-import { useNetwork } from 'wagmi';
 import useLocales from '../../../hooks/useLocales';
+import { getGlobalChains } from '../../../defaultClient';
 
 const MoreIcon = (
   <svg
@@ -44,7 +41,7 @@ const MobileConnectors: React.FC = () => {
 
   const locales = useLocales();
 
-  const { chains } = useNetwork();
+  const chains = getGlobalChains();
 
   const { openDefaultWalletConnect } = useDefaultWalletConnect();
   const wallets = useDefaultWallets().filter(

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -1,9 +1,5 @@
-import {
-  Connector,
-  configureChains,
-  ChainProviderFn,
-} from 'wagmi';
-import { Chain, mainnet, polygon, optimism, arbitrum } from 'wagmi/chains'
+import { Connector, configureChains, ChainProviderFn } from 'wagmi';
+import { Chain, mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
 import { Provider } from '@wagmi/core';
 
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
@@ -16,17 +12,15 @@ import { infuraProvider } from 'wagmi/providers/infura';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 import { publicProvider } from 'wagmi/providers/public';
 
+let globalChains: Chain[];
 let globalAppName: string;
 let globalAppIcon: string;
+
 export const getAppName = () => globalAppName;
 export const getAppIcon = () => globalAppIcon;
+export const getGlobalChains = () => globalChains;
 
-const defaultChains = [
-  mainnet,
-  polygon,
-  optimism,
-  arbitrum,
-];
+const defaultChains = [mainnet, polygon, optimism, arbitrum];
 
 type DefaultConnectorsProps = {
   chains?: Chain[];
@@ -130,6 +124,8 @@ const defaultClient = ({
     chains: configuredChains,
     webSocketProvider: configuredWebSocketProvider,
   } = configureChains(chains, providers);
+
+  globalChains = configuredChains;
 
   const connectKitClient: ConnectKitClientProps = {
     autoConnect,

--- a/packages/connectkit/src/hooks/useConnect.tsx
+++ b/packages/connectkit/src/hooks/useConnect.tsx
@@ -1,9 +1,9 @@
-import { useConnect as wagmiUseConnect, useNetwork } from 'wagmi';
+import { useConnect as wagmiUseConnect } from 'wagmi';
 import { useContext } from '../components/ConnectKit';
 
 export function useConnect() {
   const context = useContext();
-  const { chains } = useNetwork();
+
   const { connectAsync, connectors } = wagmiUseConnect({
     onError(err) {
       if (err.message) {
@@ -15,12 +15,14 @@ export function useConnect() {
       }
     },
   });
+
   return {
-    connectAsync: ({ ...props }) =>
-      connectAsync({
+    connectAsync: async ({ ...props }) => {
+      return await connectAsync({
         ...props,
-        chainId: context.options?.initialChainId ?? chains[0]?.id,
-      }),
+        chainId: context.options?.initialChainId,
+      });
+    },
     connectors,
   };
 }

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -1,5 +1,6 @@
 export * as Types from './types';
-export { default as getDefaultClient } from './defaultClient';
+export { default as getDefaultClient, getGlobalChains } from './defaultClient';
+
 export { useModal } from './components/ConnectKit';
 
 export { ConnectKitProvider } from './components/ConnectKit';


### PR DESCRIPTION
Addresses: https://github.com/family/connectkit/issues/44

- Changes the way configured chains are handled around ConnectKit
- Gives developers option to turn off a targeted `chainId` during connection (will connect to the currently connected network instead)
- Gives access to the configured list of chains for developers to use before a wallet is connected
- - [wagmi's useNetwork](https://wagmi.sh/react/hooks/useNetwork) hook does not expose the available chains until after a wallet has been connected. This update now gives developers access to this list if they use the `defaultClient` helper