### PR TITLE
update: wagmi 0.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+This update moves the peer dependency wagmi up to the latest version (`0.10.x`). This does not yet include support for WalletConnect 2.0.
+
 # 1.1.1
 
 This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`0.9.x`).

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.8.3",
-    "wagmi": "^0.10.0",
+    "wagmi": "^0.10.11",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.8.3",
-    "wagmi": "^0.9.0",
+    "wagmi": "^0.10.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,7 +14,7 @@
     "next": "12.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.9.0"
+    "wagmi": "^0.10.0"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,7 +14,7 @@
     "next": "12.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.0"
+    "wagmi": "^0.10.11"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev & local-ssl-proxy --source 3001 --target 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -12,10 +12,11 @@
     "connectkit": "workspace:packages/connectkit",
     "connectkit-next-siwe": "workspace:packages/connectkit-next-siwe",
     "ethers": "^5.6.5",
+    "local-ssl-proxy": "^1.3.0",
     "next": "13.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.0"
+    "wagmi": "^0.10.11"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -15,7 +15,7 @@
     "next": "13.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.9.0"
+    "wagmi": "^0.10.0"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -15,12 +15,10 @@ const client = createClient(
     appIcon: '/app.png',
     infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
     alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
-    walletConnectOptions: false
-      ? {
-          version: '2',
-          projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
-        }
-      : undefined,
+    walletConnectOptions: {
+      version: '2',
+      projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
+    },
   })
 );
 

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -15,10 +15,13 @@ const client = createClient(
     appIcon: '/app.png',
     infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
     alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
+    // WalletConnect 2.0 coming soon
+    /*
     walletConnectOptions: {
       version: '2',
       projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
     },
+    */
   })
 );
 

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -15,6 +15,12 @@ const client = createClient(
     appIcon: '/app.png',
     infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
     alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
+    walletConnectOptions: false
+      ? {
+          version: '2',
+          projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
+        }
+      : undefined,
   })
 );
 

--- a/examples/testbench/src/styles/globals.css
+++ b/examples/testbench/src/styles/globals.css
@@ -55,3 +55,8 @@ aside {
     width: auto;
   }
 }
+
+w3m-modal {
+  z-index: 2147483647;
+  position: relative;
+}

--- a/examples/testbench/src/styles/globals.css
+++ b/examples/testbench/src/styles/globals.css
@@ -55,8 +55,3 @@ aside {
     width: auto;
   }
 }
-
-w3m-modal {
-  z-index: 2147483647;
-  position: relative;
-}

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -13,7 +13,7 @@
     "ethers": "^5.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.10.0"
+    "wagmi": "^0.10.11"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -13,7 +13,7 @@
     "ethers": "^5.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.9.0"
+    "wagmi": "^0.10.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",
     "tslib": "^1.9.3",
-    "wagmi": "^0.9.0"
+    "wagmi": "^0.10.0"
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",
     "tslib": "^1.9.3",
-    "wagmi": "^0.10.0"
+    "wagmi": "^0.10.11"
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": "0.10.x"
+    "wagmi": "0.10.11"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",
@@ -62,6 +62,6 @@
   "resolutions": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.0"
+    "wagmi": "^0.10.11"
   }
 }

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": "0.9.x"
+    "wagmi": "0.10.x"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",
@@ -62,6 +62,6 @@
   "resolutions": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.9.0"
+    "wagmi": "^0.10.0"
   }
 }

--- a/packages/connectkit/src/components/Pages/Connectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/Connectors/index.tsx
@@ -40,6 +40,7 @@ import Button from '../../Common/Button';
 import useDefaultWallets from '../../../wallets/useDefaultWallets';
 import { Connector } from 'wagmi';
 import useLocales from '../../../hooks/useLocales';
+import { getProviderUri } from '../../../wallets/wallet';
 
 const Wallets: React.FC = () => {
   const context = useContext();
@@ -57,17 +58,10 @@ const Wallets: React.FC = () => {
       case 'walletConnect':
         context.setRoute(routes.MOBILECONNECTORS);
         break;
-      /*
-        connector = new WalletConnectConnector({
-          chains: c.chains,
-          options: { ...c.options, qrcode: true },
-        });
-        break;
-        */
       case 'metaMask':
         connector = new WalletConnectConnector({
           chains: c.chains,
-          options: { ...c.options, qrcode: false },
+          options: { ...c.options, qrcode: false, version: '1' },
         });
         break;
       case 'coinbaseWallet':
@@ -86,12 +80,12 @@ const Wallets: React.FC = () => {
 
     if (!connector) return;
 
-    // TODO: Make this neater
+    // TODO: Make this neater and use the MetaMask config
     if (c.id === 'metaMask' && mobile) {
       let connnector = connector as WalletConnectConnector;
       connector.on('message', async ({ type }) => {
         if (type === 'connecting') {
-          const { uri } = (await connnector.getProvider()).connector;
+          const uri = await getProviderUri(connnector);
           const uriString = isAndroid()
             ? uri
             : `https://metamask.app.link/wc?uri=${encodeURIComponent(uri)}`;

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -1,9 +1,5 @@
-import {
-  Connector,
-  configureChains,
-  ChainProviderFn,
-} from 'wagmi';
-import { Chain, mainnet, polygon, optimism, arbitrum } from 'wagmi/chains'
+import { Connector, configureChains, ChainProviderFn } from 'wagmi';
+import { Chain, mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
 import { Provider } from '@wagmi/core';
 
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
@@ -21,16 +17,22 @@ let globalAppIcon: string;
 export const getAppName = () => globalAppName;
 export const getAppIcon = () => globalAppIcon;
 
-const defaultChains = [
-  mainnet,
-  polygon,
-  optimism,
-  arbitrum,
-];
+const defaultChains = [mainnet, polygon, optimism, arbitrum];
+
+type WalletConnectOptionsProps =
+  | {
+      version: '2';
+      projectId: string;
+    }
+  | {
+      version: '1';
+    }
+  | undefined;
 
 type DefaultConnectorsProps = {
   chains?: Chain[];
   appName: string;
+  walletConnectOptions?: WalletConnectOptionsProps;
 };
 
 type DefaultClientProps = {
@@ -45,6 +47,7 @@ type DefaultClientProps = {
   webSocketProvider?: any;
   enableWebSocketProvider?: boolean;
   stallTimeout?: number;
+  walletConnectOptions?: WalletConnectOptionsProps;
 };
 
 type ConnectKitClientProps = {
@@ -54,7 +57,21 @@ type ConnectKitClientProps = {
   webSocketProvider?: any;
 };
 
-const getDefaultConnectors = ({ chains, appName }: DefaultConnectorsProps) => {
+const getDefaultConnectors = ({
+  chains,
+  appName,
+  walletConnectOptions,
+}: DefaultConnectorsProps) => {
+  const wcOpts: WalletConnectOptionsProps =
+    walletConnectOptions?.version === '2' && walletConnectOptions?.projectId
+      ? {
+          version: '2',
+          projectId: walletConnectOptions.projectId, // WC 2.0 requires a project ID (get one here: https://cloud.walletconnect.com/sign-in)
+        }
+      : {
+          version: '1',
+        };
+
   return [
     new MetaMaskConnector({
       chains,
@@ -75,6 +92,7 @@ const getDefaultConnectors = ({ chains, appName }: DefaultConnectorsProps) => {
       chains,
       options: {
         qrcode: false,
+        ...wcOpts,
       },
     }),
     new InjectedConnector({
@@ -104,6 +122,7 @@ const defaultClient = ({
   stallTimeout,
   webSocketProvider,
   enableWebSocketProvider,
+  walletConnectOptions,
 }: DefaultClientProps) => {
   globalAppName = appName;
   if (appIcon) globalAppIcon = appIcon;
@@ -134,7 +153,12 @@ const defaultClient = ({
   const connectKitClient: ConnectKitClientProps = {
     autoConnect,
     connectors:
-      connectors ?? getDefaultConnectors({ chains: configuredChains, appName }),
+      connectors ??
+      getDefaultConnectors({
+        chains: configuredChains,
+        appName,
+        walletConnectOptions,
+      }),
     provider: provider ?? configuredProvider,
     webSocketProvider: enableWebSocketProvider // Removed by default, breaks if used in Next.js – "unhandledRejection: Error: could not detect network"
       ? webSocketProvider ?? configuredWebSocketProvider

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -62,6 +62,8 @@ const getDefaultConnectors = ({
   appName,
   walletConnectOptions,
 }: DefaultConnectorsProps) => {
+  const wcOpts: WalletConnectOptionsProps = { version: '1' };
+  /*
   const wcOpts: WalletConnectOptionsProps =
     walletConnectOptions?.version === '2' && walletConnectOptions?.projectId
       ? {
@@ -71,6 +73,7 @@ const getDefaultConnectors = ({
       : {
           version: '1',
         };
+   */
 
   return [
     new MetaMaskConnector({

--- a/packages/connectkit/src/wallets/connectors/argent.tsx
+++ b/packages/connectkit/src/wallets/connectors/argent.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -20,18 +24,13 @@ export const argent = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://apps.apple.com/app/argent/id1358741926',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -39,7 +38,7 @@ export const argent = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/frontier.tsx
+++ b/packages/connectkit/src/wallets/connectors/frontier.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const frontier = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://frontier.xyz/',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -40,7 +39,7 @@ export const frontier = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/gnosisSafe.tsx
+++ b/packages/connectkit/src/wallets/connectors/gnosisSafe.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const gnosisSafe = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://gnosis-safe.io/',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -40,7 +39,7 @@ export const gnosisSafe = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/imToken.tsx
+++ b/packages/connectkit/src/wallets/connectors/imToken.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import Logos from './../../assets/logos';
 
@@ -19,23 +23,18 @@ export const imToken = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
             return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/ledger.tsx
+++ b/packages/connectkit/src/wallets/connectors/ledger.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const ledger = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://apps.apple.com/app/ledger-live-web3-wallet/id1361671700',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -41,12 +40,12 @@ export const ledger = ({ chains }: WalletOptions): WalletProps => {
         },
         desktop: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
             return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/metaMask.tsx
+++ b/packages/connectkit/src/wallets/connectors/metaMask.tsx
@@ -1,8 +1,12 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
 
-import { isMobile, isAndroid, isMetaMask } from '../../utils';
+import { isMobile, isMetaMask, isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
 export const metaMask = ({ chains }: WalletOptions): WalletProps => {
@@ -54,12 +58,7 @@ export const metaMask = ({ chains }: WalletOptions): WalletProps => {
     installed: Boolean(!shouldUseWalletConnect ? isInstalled : false),
     createConnector: () => {
       const connector = shouldUseWalletConnect
-        ? new WalletConnectConnector({
-            chains,
-            options: {
-              qrcode: false,
-            },
-          })
+        ? getDefaultWalletConnectConnector(chains)
         : new MetaMaskConnector({
             chains,
             options: {
@@ -74,7 +73,6 @@ export const metaMask = ({ chains }: WalletOptions): WalletProps => {
         getUri: async () => {},
         getMobileConnector: shouldUseWalletConnect
           ? async () => {
-              let connnector = connector as WalletConnectConnector;
               connector.on('error', (err) => {
                 console.log('onError', err);
               });
@@ -83,7 +81,7 @@ export const metaMask = ({ chains }: WalletOptions): WalletProps => {
                 if (type === 'connecting') {
                   let uriString = '';
                   try {
-                    const { uri } = (await connnector.getProvider()).connector;
+                    const uri = await getProviderUri(connector);
                     uriString = isAndroid()
                       ? uri
                       : `https://metamask.app.link/wc?uri=${encodeURIComponent(

--- a/packages/connectkit/src/wallets/connectors/onto.tsx
+++ b/packages/connectkit/src/wallets/connectors/onto.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getProviderUri,
+  getDefaultWalletConnectConnector,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const onto = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://onto.app/en/download/',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -40,7 +39,7 @@ export const onto = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/rainbow.tsx
+++ b/packages/connectkit/src/wallets/connectors/rainbow.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const rainbow = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://apps.apple.com/app/rainbow-ethereum-wallet/id1457119021',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -40,7 +39,7 @@ export const rainbow = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/slope.tsx
+++ b/packages/connectkit/src/wallets/connectors/slope.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -22,18 +26,13 @@ export const slope = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://slope.finance/',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -41,7 +40,7 @@ export const slope = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/steak.tsx
+++ b/packages/connectkit/src/wallets/connectors/steak.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getProviderUri,
+  getDefaultWalletConnectConnector,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const steak = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://steakwallet.fi/download',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -42,7 +41,7 @@ export const steak = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/trust.tsx
+++ b/packages/connectkit/src/wallets/connectors/trust.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const trust = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://apps.apple.com/app/trust-crypto-bitcoin-wallet/id1288339409',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -42,7 +41,7 @@ export const trust = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/unstoppable.tsx
+++ b/packages/connectkit/src/wallets/connectors/unstoppable.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getProviderUri,
+  getDefaultWalletConnectConnector,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -20,18 +24,13 @@ export const unstoppable = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=io.horizontalsystems.bankwallet',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -39,7 +38,7 @@ export const unstoppable = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/connectors/walletConnect.tsx
+++ b/packages/connectkit/src/wallets/connectors/walletConnect.tsx
@@ -1,8 +1,11 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getProviderUri,
+  getDefaultWalletConnectConnector,
+} from './../wallet';
 
 import Logos from './../../assets/logos';
-import { isMobile } from '../../utils';
 
 export const walletConnect = ({ chains }: WalletOptions): WalletProps => {
   return {
@@ -18,18 +21,13 @@ export const walletConnect = ({ chains }: WalletOptions): WalletProps => {
     logoBackground: 'var(--ck-brand-walletConnect)',
     scannable: true,
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
-
-      const getUri = async () => (await connector.getProvider()).connector.uri;
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
-        qrCode: { getUri },
+        qrCode: {
+          getUri: async () => await getProviderUri(connector),
+        },
       };
     },
   };

--- a/packages/connectkit/src/wallets/connectors/zerion.tsx
+++ b/packages/connectkit/src/wallets/connectors/zerion.tsx
@@ -1,5 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import {
+  WalletProps,
+  WalletOptions,
+  getDefaultWalletConnectConnector,
+  getProviderUri,
+} from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
@@ -21,18 +25,13 @@ export const zerion = ({ chains }: WalletOptions): WalletProps => {
       website: 'https://zerion.io/',
     },
     createConnector: () => {
-      const connector = new WalletConnectConnector({
-        chains,
-        options: {
-          qrcode: false,
-        },
-      });
+      const connector = getDefaultWalletConnectConnector(chains);
 
       return {
         connector,
         mobile: {
           getUri: async () => {
-            const { uri } = (await connector.getProvider()).connector;
+            const uri = await getProviderUri(connector);
 
             return isAndroid()
               ? uri
@@ -40,7 +39,7 @@ export const zerion = ({ chains }: WalletOptions): WalletProps => {
           },
         },
         qrCode: {
-          getUri: async () => (await connector.getProvider()).connector.uri,
+          getUri: async () => await getProviderUri(connector),
         },
       };
     },

--- a/packages/connectkit/src/wallets/wallet.ts
+++ b/packages/connectkit/src/wallets/wallet.ts
@@ -3,6 +3,7 @@ import { Chain } from 'wagmi';
 import { walletConnect } from './connectors/walletConnect';
 import { metaMask } from './connectors/metaMask';
 import { coinbaseWallet } from './connectors/coinbaseWallet';
+import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect';
 
 export type WalletOptions = {
   chains: Chain[];
@@ -42,4 +43,19 @@ export const getDefaultConnectors = (chains: Chain[], appName: string) => {
   return connectors.map((c: any) => {
     return { ...c.createConnector(), ...c };
   });
+};
+
+export const getDefaultWalletConnectConnector = (chains: Chain[]) => {
+  return new WalletConnectConnector({
+    chains,
+    options: {
+      qrcode: false,
+      version: '1',
+    },
+  });
+};
+
+export const getProviderUri = async (connector: any) => {
+  const provider: any = await connector.getProvider();
+  return provider.connector.uri;
 };

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -11,7 +11,7 @@
       "connectkit": "^1.0.0",
       "ethers": "^5.6.5",
       "typescript": "^4.4.2",
-      "wagmi": "^0.10.0",
+      "wagmi": "^0.10.11",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -11,7 +11,7 @@
       "connectkit": "^1.0.0",
       "ethers": "^5.6.5",
       "typescript": "^4.4.2",
-      "wagmi": "^0.9.0",
+      "wagmi": "^0.10.0",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,6 +2924,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit-labs/ssr-dom-shim@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.0.0"
+  checksum: ccba6675ad631c6f7360af4e12e328e88d877a52ec992ae9254a1be9902ef699b7916d851b073803dd91244d0f709de2c0539a7db643889cfe341ff6e1a74eb5
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.6.0":
+  version: 1.6.1
+  resolution: "@lit/reactive-element@npm:1.6.1"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": ^1.0.0
+  checksum: fab0bcfdade9c26af2ad5115fb564bcf8ba0732a3a8be86c157851c2771e3fdc65ab38f2cd60fa121946058bf6e487461fd217f87b01f96e88ee7a95d5d866ba
+  languageName: node
+  linkType: hard
+
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -2969,6 +2985,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@motionone/animation@npm:^10.15.1":
+  version: 10.15.1
+  resolution: "@motionone/animation@npm:10.15.1"
+  dependencies:
+    "@motionone/easing": ^10.15.1
+    "@motionone/types": ^10.15.1
+    "@motionone/utils": ^10.15.1
+    tslib: ^2.3.1
+  checksum: 75b7a1e6c47c27073a578eb5559ea0a6e7075862c72e1eb1598403c8c2725f596a95b0369514c9e72f3c7439a9845c468b85a14d4e500df48e09d01b0739d4a7
+  languageName: node
+  linkType: hard
+
 "@motionone/dom@npm:10.12.0":
   version: 10.12.0
   resolution: "@motionone/dom@npm:10.12.0"
@@ -2983,6 +3011,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@motionone/dom@npm:^10.15.5":
+  version: 10.15.5
+  resolution: "@motionone/dom@npm:10.15.5"
+  dependencies:
+    "@motionone/animation": ^10.15.1
+    "@motionone/generators": ^10.15.1
+    "@motionone/types": ^10.15.1
+    "@motionone/utils": ^10.15.1
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: 2453fe3df6a2b4b339d075bcd598bda1eee1926ba0ad881edfd154362b0992c91f31c08d83c469c7e8cb8bf8ebc0ed5530972673cf5c74d99e46e3772cf5f1cb
+  languageName: node
+  linkType: hard
+
 "@motionone/easing@npm:^10.14.0":
   version: 10.14.0
   resolution: "@motionone/easing@npm:10.14.0"
@@ -2990,6 +3032,16 @@ __metadata:
     "@motionone/utils": ^10.14.0
     tslib: ^2.3.1
   checksum: c845b7a445d6dbfb6d9d830fe8c88050345988fb6e423e63c1962506995e99efe899d6e7b14a8960b7df27aa279dfdfb02202a20de01bc65dcbd416ec2315d37
+  languageName: node
+  linkType: hard
+
+"@motionone/easing@npm:^10.15.1":
+  version: 10.15.1
+  resolution: "@motionone/easing@npm:10.15.1"
+  dependencies:
+    "@motionone/utils": ^10.15.1
+    tslib: ^2.3.1
+  checksum: cf7cfcf9917525d892334c58282425aafc69d9ab9004c190bfa7cf91317a680e8143f227adc79557424e7f26cdf8478dcbb2ae467e744cebc58195d6f0b8153a
   languageName: node
   linkType: hard
 
@@ -3004,10 +3056,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@motionone/generators@npm:^10.15.1":
+  version: 10.15.1
+  resolution: "@motionone/generators@npm:10.15.1"
+  dependencies:
+    "@motionone/types": ^10.15.1
+    "@motionone/utils": ^10.15.1
+    tslib: ^2.3.1
+  checksum: 0eb6797a64d536bb5c26628343d6594a2ebc45c3c447b8ce442b4ac3a41be847b860ac009bda7968fc7d339d2ee49b18bfe36306c5dd99cf17c7d84c82de93f3
+  languageName: node
+  linkType: hard
+
+"@motionone/svelte@npm:^10.15.5":
+  version: 10.15.5
+  resolution: "@motionone/svelte@npm:10.15.5"
+  dependencies:
+    "@motionone/dom": ^10.15.5
+    tslib: ^2.3.1
+  checksum: 17c7cf75f9c2635b1f11204fc4944a62b6febe19d9ffca50b15b45019e98d74cb9c7b9c1a780d8dbd945d8f397ebc3ff97a765d16cad7aae99d1ec979c3aa5ad
+  languageName: node
+  linkType: hard
+
 "@motionone/types@npm:^10.12.0, @motionone/types@npm:^10.14.0":
   version: 10.14.0
   resolution: "@motionone/types@npm:10.14.0"
   checksum: 2fbd65f925c786b190d99867010960ffb458beda5f9b5499eeb0822094871ecbeded1aae917c194b605d80f0c56a55a13ff1e0fa4f6bad3ad8ff32fe5a3201dc
+  languageName: node
+  linkType: hard
+
+"@motionone/types@npm:^10.15.1":
+  version: 10.15.1
+  resolution: "@motionone/types@npm:10.15.1"
+  checksum: 98091f7dca257508d94d1080678c433da39a814e8e58aaa742212bf6c2a5b5e2120a6251a06e3ea522219ce6d1b6eb6aa2cab224b803fe52789033d8398ef0aa
   languageName: node
   linkType: hard
 
@@ -3019,6 +3099,27 @@ __metadata:
     hey-listen: ^1.0.8
     tslib: ^2.3.1
   checksum: eb4c0a50e458ba7e7944dba7d0b063665744fed60aef9b4670bbc26fe02bed43f26595e9515f8ca6e4899ff5f31e7d81708feb42c16bf6e91c871d310085bc48
+  languageName: node
+  linkType: hard
+
+"@motionone/utils@npm:^10.15.1":
+  version: 10.15.1
+  resolution: "@motionone/utils@npm:10.15.1"
+  dependencies:
+    "@motionone/types": ^10.15.1
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: 6ef13cd6637ec87c340e5536f849f8c40d30cc90139a3856d11cd70d78e3740f8815b0e63564fefd23c05a060da7a0ea5395390549606ed8801a7b832b74e04e
+  languageName: node
+  linkType: hard
+
+"@motionone/vue@npm:^10.15.5":
+  version: 10.15.5
+  resolution: "@motionone/vue@npm:10.15.5"
+  dependencies:
+    "@motionone/dom": ^10.15.5
+    tslib: ^2.3.1
+  checksum: c87c019edfa1224aed7f2edf3f0f764829eeebbc6efefeca2235a5cabbd1553b7516376c744a39e1f7e6b13a7699bceac02c7cb59091d4d1019d5e9dd11c8cf2
   languageName: node
   linkType: hard
 
@@ -4716,22 +4817,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:0.1.9":
-  version: 0.1.9
-  resolution: "@wagmi/chains@npm:0.1.9"
-  checksum: da2dcfccb105cebe0b6c58604adffaa99c6a9179782716d0be8ff0c4eeb6a88d23f4e09c22bdb85e0157fdbe7baea3c4244e582cc4512f98527c3432eadc5f36
+"@wagmi/chains@npm:0.1.10":
+  version: 0.1.10
+  resolution: "@wagmi/chains@npm:0.1.10"
+  checksum: 028e09f26b9bd8fc0f2a343b7b3cacd7cdbf1f3302ded3100d2bfef02bba54f3967581c6e97d510ffe5afef6c90444209d616c9a8543aca2905cef8c094532ae
   languageName: node
   linkType: hard
 
-"@wagmi/connectors@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@wagmi/connectors@npm:0.1.7"
+"@wagmi/connectors@npm:0.1.8":
+  version: 0.1.8
+  resolution: "@wagmi/connectors@npm:0.1.8"
   dependencies:
     "@coinbase/wallet-sdk": ^3.5.4
     "@ledgerhq/connect-kit-loader": ^1.0.1
     "@walletconnect/ethereum-provider": ^1.8.0
-    "@walletconnect/qrcode-modal": ^1.8.0
-    "@walletconnect/universal-provider": ^2.2.0
+    "@walletconnect/universal-provider": ^2.2.1
+    "@web3modal/standalone": ^2.0.0-rc.2
     abitype: ^0.1.8
     eventemitter3: ^4.0.7
   peerDependencies:
@@ -4740,16 +4841,16 @@ __metadata:
   peerDependenciesMeta:
     "@wagmi/core":
       optional: true
-  checksum: f5b4af6ec8c097a702f3448d04b6ec928ee0868f349b1b75418e2c00505fda56209c77d4772938fcd06ad564e7c48cbf0d02b4e5f524a43f24ae64f6cf2d0dac
+  checksum: 1a7b959ca924b3c6f69f696ff55f48de3b836e2a7e6e39462674b29a6d0297991a030c5f188d64db3fd0a4114a15e0243259df32980a9982148cdf30cd66005c
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:0.8.14":
-  version: 0.8.14
-  resolution: "@wagmi/core@npm:0.8.14"
+"@wagmi/core@npm:0.8.15":
+  version: 0.8.15
+  resolution: "@wagmi/core@npm:0.8.15"
   dependencies:
-    "@wagmi/chains": 0.1.9
-    "@wagmi/connectors": 0.1.7
+    "@wagmi/chains": 0.1.10
+    "@wagmi/connectors": 0.1.8
     abitype: ^0.2.5
     eventemitter3: ^4.0.7
     zustand: ^4.3.1
@@ -4762,7 +4863,7 @@ __metadata:
       optional: true
     "@walletconnect/ethereum-provider":
       optional: true
-  checksum: 793a10b6db62d0ff7fdb77347d6a5a44704fcfd885bc0e5ea27581bf7f2a0f1c292c171d944851c736e4f046f735c4710d2319e4058a53166e534cbb46cad51e
+  checksum: 36b6f79d175dada48998a3c5535615d55872523cd45b9bda7de3e98410774196ba2f8e722210e5f6139be8ead3299017a6bc4534d1f37e6ead4e87f2b978737a
   languageName: node
   linkType: hard
 
@@ -5184,7 +5285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/universal-provider@npm:^2.2.0":
+"@walletconnect/universal-provider@npm:^2.2.1":
   version: 2.2.1
   resolution: "@walletconnect/universal-provider@npm:2.2.1"
   dependencies:
@@ -5273,6 +5374,38 @@ __metadata:
     "@walletconnect/window-getters": ^1.0.1
     tslib: 1.14.1
   checksum: e82aea7195c6fe95c00e87bb38051c5549838c2e8302da94f1afa48206f79f0b620166c9820f847494505d282d1568e2086a1561b0493d2d0a1fa115f9106aef
+  languageName: node
+  linkType: hard
+
+"@web3modal/core@npm:2.0.0-rc.3":
+  version: 2.0.0-rc.3
+  resolution: "@web3modal/core@npm:2.0.0-rc.3"
+  dependencies:
+    buffer: 6.0.3
+    valtio: 1.8.2
+  checksum: 0cfe0cb6654a143a4646a6d264593a7144272593f7d3ce18e6bb89cef1a93d8dc6ea5d34cd6906d3b1181a4dee22c939558e767a00e9d0abc6f9de12829c06db
+  languageName: node
+  linkType: hard
+
+"@web3modal/standalone@npm:^2.0.0-rc.2":
+  version: 2.0.0-rc.3
+  resolution: "@web3modal/standalone@npm:2.0.0-rc.3"
+  dependencies:
+    "@web3modal/core": 2.0.0-rc.3
+    "@web3modal/ui": 2.0.0-rc.3
+  checksum: f7f7393597c816f83ae1b84124155db9fe8c8e6f64954ca847a300b64418bffa4d9c2029d78cc1e67ed824ce8d3b0c5d57dfb0922d7e6a86cb3d211d4d6e1fc5
+  languageName: node
+  linkType: hard
+
+"@web3modal/ui@npm:2.0.0-rc.3":
+  version: 2.0.0-rc.3
+  resolution: "@web3modal/ui@npm:2.0.0-rc.3"
+  dependencies:
+    "@web3modal/core": 2.0.0-rc.3
+    lit: 2.6.1
+    motion: 10.15.5
+    qrcode: 1.5.1
+  checksum: fe8d76fd17933efb7cb78c3e5eaf310b5726b575c5d3c8597496660032873c25bccb602d84a591f175886cb49cad6cf69e1b167d0cdd7c1dd5de41187a37611e
   languageName: node
   linkType: hard
 
@@ -5707,6 +5840,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "ansi-regex@npm:2.1.1"
+  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^4.1.0":
   version: 4.1.1
   resolution: "ansi-regex@npm:4.1.1"
@@ -5725,6 +5865,13 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "ansi-styles@npm:2.2.1"
+  checksum: ebc0e00381f2a29000d1dac8466a640ce11943cef3bda3cd0020dc042e31e1058ab59bf6169cd794a54c3a7338a61ebc404b7c91e004092dd20e028c432c9c2c
   languageName: node
   linkType: hard
 
@@ -5750,6 +5897,13 @@ __metadata:
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "ansi-styles@npm:1.0.0"
+  checksum: 6dd47dccb268b4cc1fd0dd6617067a7acd34ad2761f0438800fdd55c0d45f50a90787acd82806009c2bf467f4e2920166be03e19b23529038c1c4527d80f598b
   languageName: node
   linkType: hard
 
@@ -6573,6 +6727,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:6.0.3, buffer@npm:^6, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.4.3":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -6580,16 +6744,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
   languageName: node
   linkType: hard
 
@@ -6749,6 +6903,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^1.1.1":
+  version: 1.1.3
+  resolution: "chalk@npm:1.1.3"
+  dependencies:
+    ansi-styles: ^2.2.1
+    escape-string-regexp: ^1.0.2
+    has-ansi: ^2.0.0
+    strip-ansi: ^3.0.0
+    supports-color: ^2.0.0
+  checksum: 9d2ea6b98fc2b7878829eec223abcf404622db6c48396a9b9257f6d0ead2acf18231ae368d6a664a83f272b0679158da12e97b5229f794939e555cc574478acd
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.0.0, chalk@npm:^2.1.0, chalk@npm:^2.4.1":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -6777,6 +6944,17 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
+"chalk@npm:~0.4.0":
+  version: 0.4.0
+  resolution: "chalk@npm:0.4.0"
+  dependencies:
+    ansi-styles: ~1.0.0
+    has-color: ~0.1.0
+    strip-ansi: ~0.1.0
+  checksum: e8f04f387b9fbf746fdce4b61a633f8a0d28224d8b022603db0f2d137471a18c5bc0bc33b243df09c361688f12bd3ab8a9dd1f8b4450d5a361bfe83aadbde739
   languageName: node
   linkType: hard
 
@@ -7159,7 +7337,7 @@ __metadata:
     ethers: ">=5.5.0 <6"
     react: 17.x || 18.x
     react-dom: 17.x || 18.x
-    wagmi: 0.10.x
+    wagmi: 0.10.11
   languageName: unknown
   linkType: soft
 
@@ -7297,7 +7475,7 @@ __metadata:
     react-dom: ^18.0.0
     react-scripts: 5.0.1
     typescript: ^4.8.3
-    wagmi: ^0.10.0
+    wagmi: ^0.10.11
     web-vitals: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -8653,7 +8831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^1.0.5":
+"escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
@@ -9497,7 +9675,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.34.0
     rollup-plugin-visualizer: ^5.5.4
     tslib: ^1.9.3
-    wagmi: ^0.10.0
+    wagmi: ^0.10.11
   languageName: unknown
   linkType: soft
 
@@ -10182,10 +10360,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-ansi@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "has-ansi@npm:2.0.0"
+  dependencies:
+    ansi-regex: ^2.0.0
+  checksum: 1b51daa0214440db171ff359d0a2d17bc20061164c57e76234f614c91dbd2a79ddd68dfc8ee73629366f7be45a6df5f2ea9de83f52e1ca24433f2cc78c35d8ec
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-bigints@npm:1.0.2"
   checksum: 390e31e7be7e5c6fe68b81babb73dfc35d413604d7ee5f56da101417027a4b4ce6a27e46eff97ad040c835b5d228676eae99a9b5c3bc0e23c8e81a49241ff45b
+  languageName: node
+  linkType: hard
+
+"has-color@npm:~0.1.0":
+  version: 0.1.7
+  resolution: "has-color@npm:0.1.7"
+  checksum: 5753d76b1330bc1f5a07171f222ed0718f5ec2d64d5677800e434f183a99f7042f5cda43c9625a2d0f0204063aa03499a66f1c15283d789773b3544f18f93f58
   languageName: node
   linkType: hard
 
@@ -10480,7 +10674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy@npm:^1.18.1":
+"http-proxy@npm:^1.13.1, http-proxy@npm:^1.18.1":
   version: 1.18.1
   resolution: "http-proxy@npm:1.18.1"
   dependencies:
@@ -12177,6 +12371,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "lit-element@npm:3.2.2"
+  dependencies:
+    "@lit/reactive-element": ^1.3.0
+    lit-html: ^2.2.0
+  checksum: e1df57c02ad5ae4c42b49a5066b3b623bccf7fa6610bbc3f65bc22cbbe1546ecd6a7f717b1f01863929262f416c4b8b7a39ff166114215f93cc22f4e5b3825c3
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.2.0, lit-html@npm:^2.6.0":
+  version: 2.6.1
+  resolution: "lit-html@npm:2.6.1"
+  dependencies:
+    "@types/trusted-types": ^2.0.2
+  checksum: 32291eb5bcaa7fcc1d433522a9a62c3c3d240e49bb8c57ccea5c10014823d94f62f17e2d5361781cb6ee0b3c9078ef839de6164d5374371d650471904515e48e
+  languageName: node
+  linkType: hard
+
+"lit@npm:2.6.1":
+  version: 2.6.1
+  resolution: "lit@npm:2.6.1"
+  dependencies:
+    "@lit/reactive-element": ^1.6.0
+    lit-element: ^3.2.0
+    lit-html: ^2.6.0
+  checksum: 74f2813152a48f195784f01b6b4ff7e4e7d8fa90ac272b725d1953fa3e1d6c9dca60b77da435f34144fcdd38705480889a8ea986835676932a8559c897cea517
+  languageName: node
+  linkType: hard
+
 "load-yaml-file@npm:^0.2.0":
   version: 0.2.0
   resolution: "load-yaml-file@npm:0.2.0"
@@ -12211,6 +12435,19 @@ __metadata:
   version: 3.2.0
   resolution: "loader-utils@npm:3.2.0"
   checksum: c7b9a8dc4b3bc19e9ef563c48e3a18ea9f8bb2da1ad38a12e4b88358cfba5f148a7baf12d78fe78ffcb718ce1e062ab31fcf5c148459f1247a672a4213471e80
+  languageName: node
+  linkType: hard
+
+"local-ssl-proxy@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "local-ssl-proxy@npm:1.3.0"
+  dependencies:
+    chalk: ^1.1.1
+    http-proxy: ^1.13.1
+    nomnom: ^1.8.1
+  bin:
+    local-ssl-proxy: bin/local-ssl-proxy
+  checksum: 23950f8df0dae8efd03ea709ee539db6b0a6c87defc318eb1e7dd9e81defdc20dd4be3c7a219b43d7a3b34dddbc7815eb81d04378d9574252f8e90b7ded3ae18
   languageName: node
   linkType: hard
 
@@ -12731,6 +12968,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"motion@npm:10.15.5":
+  version: 10.15.5
+  resolution: "motion@npm:10.15.5"
+  dependencies:
+    "@motionone/animation": ^10.15.1
+    "@motionone/dom": ^10.15.5
+    "@motionone/svelte": ^10.15.5
+    "@motionone/types": ^10.15.1
+    "@motionone/utils": ^10.15.1
+    "@motionone/vue": ^10.15.5
+  checksum: 43e7883d95da6e4949b2e5ca01732bce28214f4978bf940511a3fbd8e00943ab7c00fcb28f3f1ce1ed099a404016f784243330be161c4805958deaf60d1b0571
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -12954,7 +13205,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: 4.8.3
-    wagmi: ^0.10.0
+    wagmi: ^0.10.11
   languageName: unknown
   linkType: soft
 
@@ -13040,6 +13291,16 @@ __metadata:
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
   checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
+  languageName: node
+  linkType: hard
+
+"nomnom@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "nomnom@npm:1.8.1"
+  dependencies:
+    chalk: ~0.4.0
+    underscore: ~1.6.0
+  checksum: cc6f538062741e8914b65352499c444a754d18a95f8c4b336b9183367c44335f00a9d3beb54648f6a76d5434702a3d71bf37c23ef4c960d39595ed72d376c6fd
   languageName: node
   linkType: hard
 
@@ -14699,6 +14960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-compare@npm:2.4.0":
+  version: 2.4.0
+  resolution: "proxy-compare@npm:2.4.0"
+  checksum: ff8952db96980ad7123a1368aa6fed6b1eb390c22758152805bb5e1d4511fb50e798c19deb93feaa3b22f103a758c38d265ae34e4769d4e1748ee59795dfa6b2
+  languageName: node
+  linkType: hard
+
 "pseudomap@npm:^1.0.2":
   version: 1.0.2
   resolution: "pseudomap@npm:1.0.2"
@@ -14760,7 +15028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode@npm:^1.5.0":
+"qrcode@npm:1.5.1, qrcode@npm:^1.5.0":
   version: 1.5.1
   resolution: "qrcode@npm:1.5.1"
   dependencies:
@@ -16465,6 +16733,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "strip-ansi@npm:3.0.1"
+  dependencies:
+    ansi-regex: ^2.0.0
+  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:^5.0.0, strip-ansi@npm:^5.1.0, strip-ansi@npm:^5.2.0":
   version: 5.2.0
   resolution: "strip-ansi@npm:5.2.0"
@@ -16489,6 +16766,15 @@ __metadata:
   dependencies:
     ansi-regex: ^6.0.1
   checksum: 257f78fa433520e7f9897722731d78599cb3fce29ff26a20a5e12ba4957463b50a01136f37c43707f4951817a75e90820174853d6ccc240997adc5df8f966039
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:~0.1.0":
+  version: 0.1.1
+  resolution: "strip-ansi@npm:0.1.1"
+  bin:
+    strip-ansi: cli.js
+  checksum: 31f1d4d3b86e6d968aa568bf47d712626dd748aff7d576a98ba2ed378dd60dfb1475898254b62479779231e50a38f0b7ea0b66d3b22d14cde38b769c1c747d33
   languageName: node
   linkType: hard
 
@@ -16632,6 +16918,13 @@ __metadata:
   version: 0.14.2
   resolution: "superstruct@npm:0.14.2"
   checksum: c5c4840f432da82125b923ec45faca5113217e83ae416e314d80eae012b8bb603d2e745025d173450758d116348820bc7028157f8c9a72b6beae879f94b837c0
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "supports-color@npm:2.0.0"
+  checksum: 602538c5812b9006404370b5a4b885d3e2a1f6567d314f8b4a41974ffe7d08e525bf92ae0f9c7030e3b4c78e4e34ace55d6a67a74f1571bc205959f5972f88f0
   languageName: node
   linkType: hard
 
@@ -16891,11 +17184,12 @@ __metadata:
     eslint: 8.23.1
     eslint-config-next: 12.3.0
     ethers: ^5.6.5
+    local-ssl-proxy: ^1.3.0
     next: 13.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: 4.8.3
-    wagmi: ^0.10.0
+    wagmi: ^0.10.11
   languageName: unknown
   linkType: soft
 
@@ -17257,6 +17551,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"underscore@npm:~1.6.0":
+  version: 1.6.0
+  resolution: "underscore@npm:1.6.0"
+  checksum: bfb837d95164077bd2751247dd9797546287c060d86c3a730f590948dbc132b426238e37df7bea28f39d3e3abf571de5b974809ee3c32d309280fed851588ef9
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.0
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
@@ -17486,6 +17787,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"valtio@npm:1.8.2":
+  version: 1.8.2
+  resolution: "valtio@npm:1.8.2"
+  dependencies:
+    proxy-compare: 2.4.0
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    react: ">=16.8"
+  peerDependenciesMeta:
+    react:
+      optional: true
+  checksum: 58e271988e70afe0dd5ac2c66c54e653f97010afc2439401aac449b50f903b8617a6920038e3585624817abedcffeb541093036983cba2ce8a6212c7d65f8454
+  languageName: node
+  linkType: hard
+
 "vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
@@ -17538,7 +17854,7 @@ __metadata:
     react-dom: ^18.2.0
     typescript: ^4.6.4
     vite: ^3.1.0
-    wagmi: ^0.10.0
+    wagmi: ^0.10.11
   languageName: unknown
   linkType: soft
 
@@ -17560,22 +17876,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.10.0":
-  version: 0.10.10
-  resolution: "wagmi@npm:0.10.10"
+"wagmi@npm:^0.10.11":
+  version: 0.10.11
+  resolution: "wagmi@npm:0.10.11"
   dependencies:
     "@coinbase/wallet-sdk": ^3.6.0
     "@tanstack/query-sync-storage-persister": ^4.14.5
     "@tanstack/react-query": ^4.14.5
     "@tanstack/react-query-persist-client": ^4.14.5
-    "@wagmi/core": 0.8.14
+    "@wagmi/core": 0.8.15
     "@walletconnect/ethereum-provider": ^1.8.0
     abitype: ^0.2.5
     use-sync-external-store: ^1.2.0
   peerDependencies:
     ethers: ">=5.5.1"
     react: ">=17.0.0"
-  checksum: a1a65ecab22f90b5382ac3e676e136e8889dbc377272792669be89dbad42d238f77e0957ac90c919ea54f45e03b24c3c240980a257a069e95be7ba383f4c39cd
+  checksum: fe901f541e2b533968d86df31b8f29ad8bb44269018b95ca0f3d2724e2c425d855fb18a1320061669e2fa1503c9bd9749655b9b129908128b04cc56b73dd3768
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@coinbase/wallet-sdk@npm:^3.5.4":
+  version: 3.6.3
+  resolution: "@coinbase/wallet-sdk@npm:3.6.3"
+  dependencies:
+    "@metamask/safe-event-emitter": 2.0.0
+    "@solana/web3.js": ^1.70.1
+    bind-decorator: ^1.0.11
+    bn.js: ^5.1.1
+    buffer: ^6.0.3
+    clsx: ^1.1.0
+    eth-block-tracker: 4.4.3
+    eth-json-rpc-filters: 4.2.2
+    eth-rpc-errors: 4.0.2
+    json-rpc-engine: 6.1.0
+    keccak: ^3.0.1
+    preact: ^10.5.9
+    qs: ^6.10.3
+    rxjs: ^6.6.3
+    sha.js: ^2.4.11
+    stream-browserify: ^3.0.0
+    util: ^0.12.4
+  checksum: f2ffd553f64ced32b9e9cf7fd2ec5708a5a8a4c4e5726787d3499db50cc135912c8565ec3c349b716ad8e9c7efeea682a265ffc365c78074a81345d35347621d
+  languageName: node
+  linkType: hard
+
 "@coinbase/wallet-sdk@npm:^3.6.0":
   version: 3.6.2
   resolution: "@coinbase/wallet-sdk@npm:3.6.2"
@@ -2885,6 +2910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/connect-kit-loader@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@ledgerhq/connect-kit-loader@npm:1.0.2"
+  checksum: 38475ee5a80b733fee571a8e882e7d309e0e28ef4776adb122bb4be010c54ca966c3946c1cbc78ae0d6abec62cd9ea6c7fbe4879041fe43d173bb287362fa34f
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
@@ -3204,6 +3236,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/ed25519@npm:^1.7.0":
+  version: 1.7.1
+  resolution: "@noble/ed25519@npm:1.7.1"
+  checksum: b8e50306ac70f5cecc349111997e72e897b47a28d406b96cf95d0ebe7cbdefb8380d26117d7847d94102281db200aa3a494e520f9fc12e2f292e0762cb0fa333
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "@noble/hashes@npm:1.1.5"
+  checksum: de3f095a7ac1cbf5b4b3d09f193288d4f2eec35fbadf2ed9fd7e47d8a3042fef410052ba62dc0296a185f994c11192f5357fdb1bd9178c905efd82e946c53b00
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:^1.6.3":
+  version: 1.7.1
+  resolution: "@noble/secp256k1@npm:1.7.1"
+  checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3480,12 +3533,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/web3.js@npm:^1.70.1":
+  version: 1.73.0
+  resolution: "@solana/web3.js@npm:1.73.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@noble/ed25519": ^1.7.0
+    "@noble/hashes": ^1.1.2
+    "@noble/secp256k1": ^1.6.3
+    "@solana/buffer-layout": ^4.0.0
+    agentkeepalive: ^4.2.1
+    bigint-buffer: ^1.1.5
+    bn.js: ^5.0.0
+    borsh: ^0.7.0
+    bs58: ^4.0.1
+    buffer: 6.0.1
+    fast-stable-stringify: ^1.0.0
+    jayson: ^3.4.4
+    node-fetch: 2
+    rpc-websockets: ^7.5.0
+    superstruct: ^0.14.2
+  checksum: 8bd212d3fce35ad4ad4bc2490181c3d18b6abda10b253fde5a7c6b1620cdb27f37f96d5739d3058abeded76e736b35439cae2deddb3dfd4aae8ffcdf7233223c
+  languageName: node
+  linkType: hard
+
 "@spruceid/siwe-parser@npm:^1.1.3":
   version: 1.1.3
   resolution: "@spruceid/siwe-parser@npm:1.1.3"
   dependencies:
     apg-js: ^4.1.1
   checksum: 708786ba2f10987c45c1fd8a6243ba6572ee7f320531616d71ff66044828bc24af66f5537ce09c9272bdae93fcc35b566a7804fe7997284f2ee5445a36e6add2
+  languageName: node
+  linkType: hard
+
+"@stablelib/aead@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/aead@npm:1.0.1"
+  checksum: 1a6f68d138f105d17dd65349751515bd252ab0498c77255b8555478d28415600dde493f909eb718245047a993f838dfae546071e1687566ffb7b8c3e10c918d9
   languageName: node
   linkType: hard
 
@@ -3498,6 +3582,84 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stablelib/bytes@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/bytes@npm:1.0.1"
+  checksum: 456267e08c3384abcb71d3ad3e97a6f99185ad754bac016f501ebea4e4886f37900589143b57e33bdbbf513a92fc89368c15dd4517e0540d0bdc79ecdf9dd087
+  languageName: node
+  linkType: hard
+
+"@stablelib/chacha20poly1305@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/chacha20poly1305@npm:1.0.1"
+  dependencies:
+    "@stablelib/aead": ^1.0.1
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/chacha": ^1.0.1
+    "@stablelib/constant-time": ^1.0.1
+    "@stablelib/poly1305": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 81f1a32330838d31e4dc3144d76eba7244b56d9ea38c1f604f2c34d93ed8e67e9a6167d2cfd72254c13cc46dfc1f5ce5157b37939a575295d69d9144abb4e4fb
+  languageName: node
+  linkType: hard
+
+"@stablelib/chacha@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/chacha@npm:1.0.1"
+  dependencies:
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: f061f36c4ca4bf177dd7cac11e7c65ced164f141b6065885141ae5a55f32e16ba0209aefcdcc966aef013f1da616ce901a3a80653b4b6f833cf7e3397ae2d6bd
+  languageName: node
+  linkType: hard
+
+"@stablelib/constant-time@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/constant-time@npm:1.0.1"
+  checksum: dba4f4bf508de2ff15f7f0cbd875e70391aa3ba3698290fe1ed2feb151c243ba08a90fc6fb390ec2230e30fcc622318c591a7c0e35dcb8150afb50c797eac3d7
+  languageName: node
+  linkType: hard
+
+"@stablelib/ed25519@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@stablelib/ed25519@npm:1.0.3"
+  dependencies:
+    "@stablelib/random": ^1.0.2
+    "@stablelib/sha512": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: e18279de078edac67396ba07dbb862dce0fe89efa8141c21a5b04108a29914bd51636019522323ca5097ec596a90b3028ed64e88ee009b0ac7de7c1ab6499ccb
+  languageName: node
+  linkType: hard
+
+"@stablelib/hash@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/hash@npm:1.0.1"
+  checksum: 3ff1f12d1a4082aaf4b6cdf40c2010aabe5c4209d3b40b97b5bbb0d9abc0ee94abdc545e57de0614afaea807ca0212ac870e247ec8f66cdce91ec39ce82948cf
+  languageName: node
+  linkType: hard
+
+"@stablelib/hkdf@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/hkdf@npm:1.0.1"
+  dependencies:
+    "@stablelib/hash": ^1.0.1
+    "@stablelib/hmac": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 9d45e303715a1835c8612b78e6c1b9d2b7463699b484241d8681fb5c17e0f2bbde5ce211c882134b64616a402e09177baeba80426995ff227b3654a155ab225d
+  languageName: node
+  linkType: hard
+
+"@stablelib/hmac@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/hmac@npm:1.0.1"
+  dependencies:
+    "@stablelib/constant-time": ^1.0.1
+    "@stablelib/hash": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: e3b93f7144a5846a6e30213278f7570de6d3f9d09131b95ce76d5c5c8bf37bf5d1830f2ee8d847555707271dbfd6e2461221719fd4d8b27ff06b9dd689c0ec21
+  languageName: node
+  linkType: hard
+
 "@stablelib/int@npm:^1.0.1":
   version: 1.0.1
   resolution: "@stablelib/int@npm:1.0.1"
@@ -3505,7 +3667,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stablelib/random@npm:^1.0.1":
+"@stablelib/keyagreement@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/keyagreement@npm:1.0.1"
+  dependencies:
+    "@stablelib/bytes": ^1.0.1
+  checksum: 3c8ec904dd50f72f3162f5447a0fa8f1d9ca6e24cd272d3dbe84971267f3b47f9bd5dc4e4eeedf3fbac2fe01f2d9277053e57c8e60db8c5544bfb35c62d290dd
+  languageName: node
+  linkType: hard
+
+"@stablelib/poly1305@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/poly1305@npm:1.0.1"
+  dependencies:
+    "@stablelib/constant-time": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 70b845bb0481c66b7ba3f3865d01e4c67a4dffc9616fc6de1d23efc5e828ec09de25f8e3be4e1f15a23b8e87e3036ee3d949c2fd4785047e6f7028bbec0ead18
+  languageName: node
+  linkType: hard
+
+"@stablelib/random@npm:^1.0.1, @stablelib/random@npm:^1.0.2":
   version: 1.0.2
   resolution: "@stablelib/random@npm:1.0.2"
   dependencies:
@@ -3515,10 +3696,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stablelib/sha256@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/sha256@npm:1.0.1"
+  dependencies:
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/hash": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 38669871e1bda72eb537629ebceac1c72da8890273a9fbe088f81f6d14c1ec04e78be8c5b455380a06c67f8e62b2508e11e9063fcc257dbaa1b5c27ac756ba77
+  languageName: node
+  linkType: hard
+
+"@stablelib/sha512@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/sha512@npm:1.0.1"
+  dependencies:
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/hash": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: b7c82f7608a35948a2147a534c0c9afc80deab3fd5f72a2e27b2454e7c0c6944d39381be3abcb1b7fac5b824ba030ae3e98209d517a579c143d8ed63930b042f
+  languageName: node
+  linkType: hard
+
 "@stablelib/wipe@npm:^1.0.1":
   version: 1.0.1
   resolution: "@stablelib/wipe@npm:1.0.1"
   checksum: 287802eb146810a46ba72af70b82022caf83a8aeebde23605f5ee0decf64fe2b97a60c856e43b6617b5801287c30cfa863cfb0469e7fcde6f02d143cf0c6cbf4
+  languageName: node
+  linkType: hard
+
+"@stablelib/x25519@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@stablelib/x25519@npm:1.0.3"
+  dependencies:
+    "@stablelib/keyagreement": ^1.0.1
+    "@stablelib/random": ^1.0.2
+    "@stablelib/wipe": ^1.0.1
+  checksum: f8537066b542b6770c1b5b2ae5ad0688d1b986e4bf818067c152c123a5471531987bbf024224f75f387f481ccc5b628e391e49e92102b8b1a3e2d449d6105402
   languageName: node
   linkType: hard
 
@@ -4502,21 +4716,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@wagmi/chains@npm:0.1.0"
-  checksum: 6c7e117907e4204cdc124c80e414f5c76f3f197d3e920972452c58b9556c9cdf964e76ef77ea70ff0728a0b3c6cadd15f764ca425ca70e7038af9a881cdc11da
+"@wagmi/chains@npm:0.1.9":
+  version: 0.1.9
+  resolution: "@wagmi/chains@npm:0.1.9"
+  checksum: da2dcfccb105cebe0b6c58604adffaa99c6a9179782716d0be8ff0c4eeb6a88d23f4e09c22bdb85e0157fdbe7baea3c4244e582cc4512f98527c3432eadc5f36
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@wagmi/core@npm:0.8.0"
+"@wagmi/connectors@npm:0.1.7":
+  version: 0.1.7
+  resolution: "@wagmi/connectors@npm:0.1.7"
   dependencies:
-    "@wagmi/chains": ^0.1.0
+    "@coinbase/wallet-sdk": ^3.5.4
+    "@ledgerhq/connect-kit-loader": ^1.0.1
+    "@walletconnect/ethereum-provider": ^1.8.0
+    "@walletconnect/qrcode-modal": ^1.8.0
+    "@walletconnect/universal-provider": ^2.2.0
     abitype: ^0.1.8
     eventemitter3: ^4.0.7
-    zustand: ^4.1.4
+  peerDependencies:
+    "@wagmi/core": 0.8.x
+    ethers: ^5.0.0
+  peerDependenciesMeta:
+    "@wagmi/core":
+      optional: true
+  checksum: f5b4af6ec8c097a702f3448d04b6ec928ee0868f349b1b75418e2c00505fda56209c77d4772938fcd06ad564e7c48cbf0d02b4e5f524a43f24ae64f6cf2d0dac
+  languageName: node
+  linkType: hard
+
+"@wagmi/core@npm:0.8.14":
+  version: 0.8.14
+  resolution: "@wagmi/core@npm:0.8.14"
+  dependencies:
+    "@wagmi/chains": 0.1.9
+    "@wagmi/connectors": 0.1.7
+    abitype: ^0.2.5
+    eventemitter3: ^4.0.7
+    zustand: ^4.3.1
   peerDependencies:
     "@coinbase/wallet-sdk": ">=3.6.0"
     "@walletconnect/ethereum-provider": ">=1.7.5"
@@ -4526,7 +4762,7 @@ __metadata:
       optional: true
     "@walletconnect/ethereum-provider":
       optional: true
-  checksum: e731d12bdcba8969577972e607da6d35a8595a7903e1ac8a94278cf2213e3fec6a210c3131125bf41a3d2b21e768ffefe9b370c803cc4d7b4864f0e92a911b9e
+  checksum: 793a10b6db62d0ff7fdb77347d6a5a44704fcfd885bc0e5ea27581bf7f2a0f1c292c171d944851c736e4f046f735c4710d2319e4058a53166e534cbb46cad51e
   languageName: node
   linkType: hard
 
@@ -4552,6 +4788,30 @@ __metadata:
     "@walletconnect/types": ^1.8.0
     "@walletconnect/utils": ^1.8.0
   checksum: 48aab7d11eeaaccf6612d335766eb6439f2ce3c446a87b7a974b6fb11076d3bc000f947c0822790fdaa6ba50df073c581750eb5dcda47359bf29c94b76919394
+  languageName: node
+  linkType: hard
+
+"@walletconnect/core@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@walletconnect/core@npm:2.2.1"
+  dependencies:
+    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/jsonrpc-provider": ^1.0.6
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/jsonrpc-ws-connection": ^1.0.6
+    "@walletconnect/keyvaluestorage": ^1.0.2
+    "@walletconnect/logger": ^2.0.1
+    "@walletconnect/relay-api": ^1.0.7
+    "@walletconnect/relay-auth": ^1.0.4
+    "@walletconnect/safe-json": ^1.0.1
+    "@walletconnect/time": ^1.0.2
+    "@walletconnect/types": 2.2.1
+    "@walletconnect/utils": 2.2.1
+    events: ^3.3.0
+    lodash.isequal: 4.5.0
+    pino: 7.11.0
+    uint8arrays: 3.1.0
+  checksum: f3bdac1b62c08bc793441f41d0735c3af9cd76ab1c0a358f6ec261ef0cdd4918b80bd2d9efe49da92a70e703b5cccfe7c5454f816ee841647f72f65ef5b0cd8b
   languageName: node
   linkType: hard
 
@@ -4596,6 +4856,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/environment@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/environment@npm:1.0.1"
+  dependencies:
+    tslib: 1.14.1
+  checksum: a18731d857bdca73910147e59992cef3c6e292c37ab3d3013307bd706f06cb216aa804f0f48b25a78df6493ad8127e633629f4b50acb4f69d3765d6ac0524f68
+  languageName: node
+  linkType: hard
+
 "@walletconnect/ethereum-provider@npm:^1.8.0":
   version: 1.8.0
   resolution: "@walletconnect/ethereum-provider@npm:1.8.0"
@@ -4609,6 +4878,27 @@ __metadata:
     eip1193-provider: 1.0.1
     eventemitter3: 4.0.7
   checksum: eaf8a113498673d023fc96bec1248bc9640d0bd78beea906f4d9dc5388db236c1436c00301e30f7b46abec59b22e0bb6d72e5a08837d3d021f096677a89005d6
+  languageName: node
+  linkType: hard
+
+"@walletconnect/events@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/events@npm:1.0.1"
+  dependencies:
+    keyvaluestorage-interface: ^1.0.0
+    tslib: 1.14.1
+  checksum: d28aa4dcc981bdaf38f0aeed979731ca793cead7e7a4ee730a9146d99d89db09a86c8e3192ed860638283276961c0723ba00cf3b8776f0692b36ec7df6c01be4
+  languageName: node
+  linkType: hard
+
+"@walletconnect/heartbeat@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/heartbeat@npm:1.0.1"
+  dependencies:
+    "@walletconnect/events": ^1.0.1
+    "@walletconnect/time": ^1.0.2
+    tslib: 1.14.1
+  checksum: 7591f92327cfca702eeeef277e66de036ed871b62d56dc1f8fa5f942301ca8e7e43eae4d9a1ca8399b8d433c4f6f32942af32cd9a4caca82eef4939dc484c6bb
   languageName: node
   linkType: hard
 
@@ -4634,6 +4924,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/jsonrpc-http-connection@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@walletconnect/jsonrpc-http-connection@npm:1.0.4"
+  dependencies:
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/safe-json": ^1.0.1
+    cross-fetch: ^3.1.4
+    tslib: 1.14.1
+  checksum: 195835deb7e4b26e48f11b0096d9dcff7bbed7fc4577b7528fbfe56e68f60574789efcc2caf354dc9ef09abd7ada6f64a9d1c6d5949a49e80557d114b667f090
+  languageName: node
+  linkType: hard
+
 "@walletconnect/jsonrpc-provider@npm:^1.0.5":
   version: 1.0.5
   resolution: "@walletconnect/jsonrpc-provider@npm:1.0.5"
@@ -4641,6 +4943,17 @@ __metadata:
     "@walletconnect/jsonrpc-utils": ^1.0.3
     "@walletconnect/safe-json": ^1.0.0
   checksum: 2a7b5dd3ab9e38d2f805b846cba657fbc0cade495faa2ad1e80d94947b48e0b42730e8ab01654384b5b4ce9e6814e03df44329e4c0edd5b5c12ab565795e9b1d
+  languageName: node
+  linkType: hard
+
+"@walletconnect/jsonrpc-provider@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@walletconnect/jsonrpc-provider@npm:1.0.6"
+  dependencies:
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/safe-json": ^1.0.1
+    tslib: 1.14.1
+  checksum: cc323c4a6a29693a0cb920dd6f136ed55a2a12c329b5568f9519cf1a5e5e2e8b78bfa45c2eacaa6cde43609afae82debed29b5e3ba5c5ec722d1dd1bb9ea0901
   languageName: node
   linkType: hard
 
@@ -4653,6 +4966,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/jsonrpc-types@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@walletconnect/jsonrpc-types@npm:1.0.2"
+  dependencies:
+    keyvaluestorage-interface: ^1.0.0
+    tslib: 1.14.1
+  checksum: 6878d184bfc49e5c8190586c451895eb48a576015f0556527df81b94f52977f61d456b237c662ffbff28e972f8f18b9cc4e06f0e94eddfb9fdeed6fdb4a98c5f
+  languageName: node
+  linkType: hard
+
 "@walletconnect/jsonrpc-utils@npm:^1.0.3":
   version: 1.0.3
   resolution: "@walletconnect/jsonrpc-utils@npm:1.0.3"
@@ -4660,6 +4983,58 @@ __metadata:
     "@walletconnect/environment": ^1.0.0
     "@walletconnect/jsonrpc-types": ^1.0.1
   checksum: 143e7ea1829165d4e86a674a96b7355c1e188a02a729d58d476baf0a24b21e7d1f55507682f3517ade57d1bd89be1359423d977dbf5265c3b39e16e0f62e3e73
+  languageName: node
+  linkType: hard
+
+"@walletconnect/jsonrpc-utils@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@walletconnect/jsonrpc-utils@npm:1.0.4"
+  dependencies:
+    "@walletconnect/environment": ^1.0.1
+    "@walletconnect/jsonrpc-types": ^1.0.2
+    tslib: 1.14.1
+  checksum: 33c0897bc4492bb8bf91935e3699e9bb3a644caa6b54561c4849f3828ba7e604339fe1bd89116ed685e57746d5a445242342b8cfe8879d77bd63bbf4924786f8
+  languageName: node
+  linkType: hard
+
+"@walletconnect/jsonrpc-ws-connection@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@walletconnect/jsonrpc-ws-connection@npm:1.0.6"
+  dependencies:
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/safe-json": ^1.0.1
+    events: ^3.3.0
+    tslib: 1.14.1
+    ws: ^7.5.1
+  checksum: 491cd99abbd3d12d0a9915a551d6a8cefb0d6f27d24e2ab67435fb85fbac4d964a73640c922c665c627bedeb0e2575232a1c6cb11499e0a25a10a35f5bf3b599
+  languageName: node
+  linkType: hard
+
+"@walletconnect/keyvaluestorage@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@walletconnect/keyvaluestorage@npm:1.0.2"
+  dependencies:
+    safe-json-utils: ^1.1.1
+    tslib: 1.14.1
+  peerDependencies:
+    "@react-native-async-storage/async-storage": 1.x
+    lokijs: 1.x
+  peerDependenciesMeta:
+    "@react-native-async-storage/async-storage":
+      optional: true
+    lokijs:
+      optional: true
+  checksum: d695c2efcfa013a43cfaa20c85281df7d364a4452d11a4312a695298bd0e50d04b0e21c828f33f46fb020ea9796e60a6b23041a85f29bd10beeba7d0da24539f
+  languageName: node
+  linkType: hard
+
+"@walletconnect/logger@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@walletconnect/logger@npm:2.0.1"
+  dependencies:
+    pino: 7.11.0
+    tslib: 1.14.1
+  checksum: b686679d176d5d22a3441d93e71be2652e6c447682a6d6f014baf7c2d9dcd23b93e2f434d4410e33cc532d068333f6b3c1d899aeb0d6f60cc296ed17f57b0c2c
   languageName: node
   linkType: hard
 
@@ -4695,10 +5070,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/relay-api@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@walletconnect/relay-api@npm:1.0.7"
+  dependencies:
+    "@walletconnect/jsonrpc-types": ^1.0.2
+    tslib: 1.14.1
+  checksum: 5078d60ece3215326be9c0bd79e605256b7e6f1407c4abf848769b038f3bdb82490cb47523b142797269fc48f4ccab726826ba8e4fad25feb8722c73a43d403f
+  languageName: node
+  linkType: hard
+
+"@walletconnect/relay-auth@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@walletconnect/relay-auth@npm:1.0.4"
+  dependencies:
+    "@stablelib/ed25519": ^1.0.2
+    "@stablelib/random": ^1.0.1
+    "@walletconnect/safe-json": ^1.0.1
+    "@walletconnect/time": ^1.0.2
+    tslib: 1.14.1
+    uint8arrays: ^3.0.0
+  checksum: 35b3229d7b57e74fdb8fe6827d8dd8291dc60bacda880a57b2acb47a34d38f12be46c971c9eff361eb4073e896648b550de7a7a3852ef3752f9619c08dfba891
+  languageName: node
+  linkType: hard
+
 "@walletconnect/safe-json@npm:1.0.0, @walletconnect/safe-json@npm:^1.0.0":
   version: 1.0.0
   resolution: "@walletconnect/safe-json@npm:1.0.0"
   checksum: a8ee161cad37242983522d19ace57c2d2725b5b1cf5fd4d61e3e5f4190a2b369acc4cd0fa40774b50cf4aa322f477e31b7841a6b8f0d84a3af12da8c4344e9b7
+  languageName: node
+  linkType: hard
+
+"@walletconnect/safe-json@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/safe-json@npm:1.0.1"
+  dependencies:
+    tslib: 1.14.1
+  checksum: 361082da2ff325f0084c07a96b099a4bd4e596717a0e625d03c1cb27a4f183b5a12dd6252772708fb874ecdde3a085f4fd4d4b1e0abb27b4dead011ea9b6d49c
+  languageName: node
+  linkType: hard
+
+"@walletconnect/sign-client@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@walletconnect/sign-client@npm:2.2.1"
+  dependencies:
+    "@walletconnect/core": 2.2.1
+    "@walletconnect/events": ^1.0.1
+    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/jsonrpc-provider": ^1.0.6
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/logger": ^2.0.1
+    "@walletconnect/time": ^1.0.2
+    "@walletconnect/types": 2.2.1
+    "@walletconnect/utils": 2.2.1
+    events: ^3.3.0
+    pino: 7.11.0
+  checksum: 6dc558a6c9070463c94e77f46dfb0f6d457fcf02cda6f01cea8d4179a6c673884d1dc01544c4938458f64846cab4a17c80c549f782e7ec8bb8d82741da564886
   languageName: node
   linkType: hard
 
@@ -4727,10 +5154,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/time@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@walletconnect/time@npm:1.0.2"
+  dependencies:
+    tslib: 1.14.1
+  checksum: e3fc0113ca9e7ecedfc65f9e1517196682d5ffcda60750f51073b8d704719a17fea75da8b242c804bfa5b994707723043892a2db3cc86988b190b7b8711fe3c0
+  languageName: node
+  linkType: hard
+
+"@walletconnect/types@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@walletconnect/types@npm:2.2.1"
+  dependencies:
+    "@walletconnect/events": ^1.0.1
+    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/jsonrpc-types": ^1.0.2
+    "@walletconnect/keyvaluestorage": ^1.0.2
+    "@walletconnect/logger": ^2.0.1
+    events: ^3.3.0
+  checksum: 187335d0b2d860cad7ed3687b05db7e09fab70657e206736becd4341f2e3cf3860ea783fabe5094353ba600ec3477f65570523b25d3b72f6899d335c5680d8e6
+  languageName: node
+  linkType: hard
+
 "@walletconnect/types@npm:^1.8.0":
   version: 1.8.0
   resolution: "@walletconnect/types@npm:1.8.0"
   checksum: 194d615888068030183489222641332987846aa5c6bcf0a62fa60ca7a282b9f94932c49fcd2b293a859e98624fe3e7a2d3c5fb66545fe30d3391e7ac91a99e34
+  languageName: node
+  linkType: hard
+
+"@walletconnect/universal-provider@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "@walletconnect/universal-provider@npm:2.2.1"
+  dependencies:
+    "@walletconnect/jsonrpc-http-connection": ^1.0.4
+    "@walletconnect/jsonrpc-provider": ^1.0.6
+    "@walletconnect/jsonrpc-types": ^1.0.2
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/logger": ^2.0.1
+    "@walletconnect/sign-client": 2.2.1
+    "@walletconnect/types": 2.2.1
+    "@walletconnect/utils": 2.2.1
+    eip1193-provider: 1.0.1
+    events: ^3.3.0
+    pino: 7.11.0
+  checksum: 8513176f7a3ec7cfbb663ceea262e420bf081b14fa0683088caa23b825f6442a85e0b536bfe263da4c4393c33b1848eb593e51132788e570bca2e858b3f84cb2
+  languageName: node
+  linkType: hard
+
+"@walletconnect/utils@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@walletconnect/utils@npm:2.2.1"
+  dependencies:
+    "@stablelib/chacha20poly1305": 1.0.1
+    "@stablelib/hkdf": 1.0.1
+    "@stablelib/random": ^1.0.2
+    "@stablelib/sha256": 1.0.1
+    "@stablelib/x25519": ^1.0.3
+    "@walletconnect/jsonrpc-utils": ^1.0.4
+    "@walletconnect/relay-api": ^1.0.7
+    "@walletconnect/safe-json": ^1.0.1
+    "@walletconnect/time": ^1.0.2
+    "@walletconnect/types": 2.2.1
+    "@walletconnect/window-getters": ^1.0.1
+    "@walletconnect/window-metadata": ^1.0.1
+    detect-browser: 5.3.0
+    query-string: 7.1.1
+    uint8arrays: 3.1.0
+  checksum: 3a506e84dbe394ca934356821b46d0e10a1f34f73f7fac0ba9c048bb72b6a2c60c10b41c6ab59997d6242c1dff99289ecaac649b199fac24fc527eb3da509635
   languageName: node
   linkType: hard
 
@@ -4756,12 +5248,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/window-getters@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/window-getters@npm:1.0.1"
+  dependencies:
+    tslib: 1.14.1
+  checksum: fae312c4e1be5574d97f071de58e6aa0d0296869761499caf9d4a9a5fd2643458af32233a2120521b00873a599ff88457d405bd82ced5fb5bd6dc3191c07a3e5
+  languageName: node
+  linkType: hard
+
 "@walletconnect/window-metadata@npm:1.0.0":
   version: 1.0.0
   resolution: "@walletconnect/window-metadata@npm:1.0.0"
   dependencies:
     "@walletconnect/window-getters": ^1.0.0
   checksum: eec506ff6d35ae6e88db1e38b6f514f6cbf1a45b979878e5e50819d229b616fc645a2b0816145b61acda2701042160a4e0685f080927b87461853a62a887a9e9
+  languageName: node
+  linkType: hard
+
+"@walletconnect/window-metadata@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@walletconnect/window-metadata@npm:1.0.1"
+  dependencies:
+    "@walletconnect/window-getters": ^1.0.1
+    tslib: 1.14.1
+  checksum: e82aea7195c6fe95c00e87bb38051c5549838c2e8302da94f1afa48206f79f0b620166c9820f847494505d282d1568e2086a1561b0493d2d0a1fa115f9106aef
   languageName: node
   linkType: hard
 
@@ -4956,12 +5467,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:^0.1.7, abitype@npm:^0.1.8":
+"abitype@npm:^0.1.8":
   version: 0.1.8
   resolution: "abitype@npm:0.1.8"
   peerDependencies:
     typescript: ">=4.7.4"
   checksum: 75db603ca20adaafd66c1097ab190cde333868ce5d5328b670574bd7e99dea92d1857eb5ff24405e4828c7cdaa0fec88142a4cff7883523b8ea2b8c328e8be45
+  languageName: node
+  linkType: hard
+
+"abitype@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "abitype@npm:0.2.5"
+  peerDependencies:
+    typescript: ">=4.7.4"
+    zod: ">=3.19.1"
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: 46d2060d3b89ef49a88059fa0251eadf744f013246b1682f867d1657f695075da7d736caa61e6b427613e508cd691bbed5794321bd7e5862e6a46dd18e7aad3e
   languageName: node
   linkType: hard
 
@@ -5433,6 +5957,13 @@ __metadata:
   version: 1.0.0
   resolution: "at-least-node@npm:1.0.0"
   checksum: 463e2f8e43384f1afb54bc68485c436d7622acec08b6fad269b421cb1d29cebb5af751426793d0961ed243146fe4dc983402f6d5a51b720b277818dbf6f2e49e
+  languageName: node
+  linkType: hard
+
+"atomic-sleep@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "atomic-sleep@npm:1.0.0"
+  checksum: b95275afb2f80732f22f43a60178430c468906a415a7ff18bcd0feeebc8eec3930b51250aeda91a476062a90e07132b43a1794e8d8ffcf9b650e8139be75fa36
   languageName: node
   linkType: hard
 
@@ -6628,7 +7159,7 @@ __metadata:
     ethers: ">=5.5.0 <6"
     react: 17.x || 18.x
     react-dom: 17.x || 18.x
-    wagmi: 0.9.x
+    wagmi: 0.10.x
   languageName: unknown
   linkType: soft
 
@@ -6766,7 +7297,7 @@ __metadata:
     react-dom: ^18.0.0
     react-scripts: 5.0.1
     typescript: ^4.8.3
-    wagmi: ^0.9.0
+    wagmi: ^0.10.0
     web-vitals: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -7363,7 +7894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-browser@npm:^5.3.0":
+"detect-browser@npm:5.3.0, detect-browser@npm:^5.3.0":
   version: 5.3.0
   resolution: "detect-browser@npm:5.3.0"
   checksum: dd6e08d55da1d9e0f22510ac79872078ae03d9dfa13c5e66c96baedc1c86567345a88f96949161f6be8f3e0fafa93bf179bdb1cd311b14f5f163112fcc70ab49
@@ -7616,6 +8147,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexify@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "duplexify@npm:4.1.2"
+  dependencies:
+    end-of-stream: ^1.4.1
+    inherits: ^2.0.3
+    readable-stream: ^3.1.1
+    stream-shift: ^1.0.0
+  checksum: 964376c61c0e92f6ed0694b3ba97c84f199413dc40ab8dfdaef80b7a7f4982fcabf796214e28ed614a5bc1ec45488a29b81e7d46fa3f5ddf65bcb118c20145ad
+  languageName: node
+  linkType: hard
+
 "ee-first@npm:1.1.1":
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
@@ -7727,6 +8270,15 @@ __metadata:
   dependencies:
     iconv-lite: ^0.6.2
   checksum: bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.4.1":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: ^1.4.0
+  checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
   languageName: node
   linkType: hard
 
@@ -8799,7 +9351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.0.0, events@npm:^3.2.0":
+"events@npm:^3.0.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
@@ -8945,7 +9497,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.34.0
     rollup-plugin-visualizer: ^5.5.4
     tslib: ^1.9.3
-    wagmi: ^0.9.0
+    wagmi: ^0.10.0
   languageName: unknown
   linkType: soft
 
@@ -8980,6 +9532,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-redact@npm:^3.0.0":
+  version: 3.1.2
+  resolution: "fast-redact@npm:3.1.2"
+  checksum: a30eb6b6830333ab213e0def55f46453ca777544dbd3a883016cb590a0eeb95e6fdf546553c1a13d509896bfba889b789991160a6d0996ceb19fce0a02e8b753
   languageName: node
   linkType: hard
 
@@ -9074,6 +9633,13 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
   languageName: node
   linkType: hard
 
@@ -11683,6 +12249,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.isequal@npm:4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
@@ -12191,6 +12764,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multiformats@npm:^9.4.2":
+  version: 9.9.0
+  resolution: "multiformats@npm:9.9.0"
+  checksum: d3e8c1be400c09a014f557ea02251a2710dbc9fca5aa32cc702ff29f636c5471e17979f30bdcb0a9cbb556f162a8591dc2e1219c24fc21394a56115b820bb84e
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
@@ -12374,7 +12954,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: 4.8.3
-    wagmi: ^0.9.0
+    wagmi: ^0.10.0
   languageName: unknown
   linkType: soft
 
@@ -12655,6 +13235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-exit-leak-free@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "on-exit-leak-free@npm:0.2.0"
+  checksum: d22b0f0538069110626b578db6e68b6ee0e85b1ee9cc5ef9b4de1bba431431d6a8da91a61e09d2ad46f22a96f968e5237833cb9d0b69bc4d294f7ec82f609b05
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -12671,7 +13258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -12999,6 +13586,44 @@ __metadata:
   version: 5.0.0
   resolution: "pify@npm:5.0.0"
   checksum: 443e3e198ad6bfa8c0c533764cf75c9d5bc976387a163792fb553ffe6ce923887cf14eebf5aea9b7caa8eab930da8c33612990ae85bd8c2bc18bedb9eae94ecb
+  languageName: node
+  linkType: hard
+
+"pino-abstract-transport@npm:v0.5.0":
+  version: 0.5.0
+  resolution: "pino-abstract-transport@npm:0.5.0"
+  dependencies:
+    duplexify: ^4.1.2
+    split2: ^4.0.0
+  checksum: c503f867de3189f8217ab9cf794e8a631dddd0029a829f0f985f5511308152ebd53e363764fbc5570b3d1c715b341e3923456ce16ad84cd41be2b9a074ada234
+  languageName: node
+  linkType: hard
+
+"pino-std-serializers@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "pino-std-serializers@npm:4.0.0"
+  checksum: 89d487729b58c9d3273a0ee851ead068d6d2e2ccc1af8e1c1d28f1b3442423679bec7ec04d9a2aba36f94f335e82be9f4de19dc4fbc161e71c136aaa15b85ad3
+  languageName: node
+  linkType: hard
+
+"pino@npm:7.11.0":
+  version: 7.11.0
+  resolution: "pino@npm:7.11.0"
+  dependencies:
+    atomic-sleep: ^1.0.0
+    fast-redact: ^3.0.0
+    on-exit-leak-free: ^0.2.0
+    pino-abstract-transport: v0.5.0
+    pino-std-serializers: ^4.0.0
+    process-warning: ^1.0.0
+    quick-format-unescaped: ^4.0.3
+    real-require: ^0.1.0
+    safe-stable-stringify: ^2.1.0
+    sonic-boom: ^2.2.1
+    thread-stream: ^0.15.1
+  bin:
+    pino: bin.js
+  checksum: b919e7dbe41de978bb050dcef94fd687c012eb78d344a18f75f04ce180d5810fc162be1f136722d70cd005ed05832c4023a38b9acbc1076ae63c9f5ec5ca515c
   languageName: node
   linkType: hard
 
@@ -14010,6 +14635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process-warning@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "process-warning@npm:1.0.0"
+  checksum: c708a03241deec3cabaeee39c4f9ee8c4d71f1c5ef9b746c8252cdb952a6059068cfcdaf348399775244cbc441b6ae5e26a9c87ed371f88335d84f26d19180f9
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -14171,6 +14803,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"query-string@npm:7.1.1":
+  version: 7.1.1
+  resolution: "query-string@npm:7.1.1"
+  dependencies:
+    decode-uri-component: ^0.2.0
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: b227d1f588ae93f9f0ad078c6b811295fa151dc5a160a03bb2bac5fa0e6919cb1daa570aad1d288e77c8e89fde5362ba505b1014e6e793da9b1e885b59a690a6
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -14182,6 +14826,13 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"quick-format-unescaped@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "quick-format-unescaped@npm:4.0.4"
+  checksum: 7bc32b99354a1aa46c089d2a82b63489961002bb1d654cee3e6d2d8778197b68c2d854fd23d8422436ee1fdfd0abaddc4d4da120afe700ade68bd357815b26fd
   languageName: node
   linkType: hard
 
@@ -14504,7 +15155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.6, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -14521,6 +15172,13 @@ __metadata:
   dependencies:
     picomatch: ^2.2.1
   checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
+  languageName: node
+  linkType: hard
+
+"real-require@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "real-require@npm:0.1.0"
+  checksum: 96745583ed4f82cd5c6a6af012fd1d3c6fc2f13ae1bcff1a3c4f8094696013a1a07c82c5aa66a403d7d4f84949fc2203bc927c7ad120caad125941ca2d7e5e8e
   languageName: node
   linkType: hard
 
@@ -15005,6 +15663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-stable-stringify@npm:^2.1.0":
+  version: 2.4.2
+  resolution: "safe-stable-stringify@npm:2.4.2"
+  checksum: 0324ba2e40f78cae63e31a02b1c9bdf1b786621f9e8760845608eb9e81aef401944ac2078e5c9c1533cf516aea34d08fa8052ca853637ced84b791caaf1e394e
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -15437,6 +16102,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sonic-boom@npm:^2.2.1":
+  version: 2.8.0
+  resolution: "sonic-boom@npm:2.8.0"
+  dependencies:
+    atomic-sleep: ^1.0.0
+  checksum: c7f9c89f931d7f60f8e0741551a729f0d81e6dc407a99420fc847a9a4c25af048a615b1188ab3c4f1fb3708fe4904973ddab6ebcc8ed5b78b50ab81a99045910
+  languageName: node
+  linkType: hard
+
 "source-list-map@npm:^2.0.0, source-list-map@npm:^2.0.1":
   version: 2.0.1
   resolution: "source-list-map@npm:2.0.1"
@@ -15582,6 +16256,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split2@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "split2@npm:4.1.0"
+  checksum: ec581597cb74c13cdfb5e2047543dd40cb1e8e9803c7b1e0c29ede05f2b4f049b2d6e7f2788a225d544549375719658b8f38e9366364dec35dc7a12edfda5ee5
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -15642,6 +16323,13 @@ __metadata:
     inherits: ~2.0.4
     readable-stream: ^3.5.0
   checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
+  languageName: node
+  linkType: hard
+
+"stream-shift@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "stream-shift@npm:1.0.1"
+  checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
   languageName: node
   linkType: hard
 
@@ -16207,7 +16895,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: 4.8.3
-    wagmi: ^0.9.0
+    wagmi: ^0.10.0
   languageName: unknown
   linkType: soft
 
@@ -16222,6 +16910,15 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: b6937a38c80c7f84d9c11dd75e49d5c44f71d95e810a3250bd1f1797fc7117c57698204adf676b71497acc205d769d65c16ae8fa10afad832ae1322630aef10a
+  languageName: node
+  linkType: hard
+
+"thread-stream@npm:^0.15.1":
+  version: 0.15.2
+  resolution: "thread-stream@npm:0.15.2"
+  dependencies:
+    real-require: ^0.1.0
+  checksum: 0547795a8f357ba1ac0dba29c71f965182e29e21752951a04a7167515ee37524bfba6c410f31e65a01a8d3e5b93400b812889aa09523e38ce4d744c894ffa6c0
   languageName: node
   linkType: hard
 
@@ -16355,7 +17052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:1.14.1, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -16527,6 +17224,24 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  languageName: node
+  linkType: hard
+
+"uint8arrays@npm:3.1.0":
+  version: 3.1.0
+  resolution: "uint8arrays@npm:3.1.0"
+  dependencies:
+    multiformats: ^9.4.2
+  checksum: 77fe0c8644417a849f5cfc0e5a5308c65e3b779a56f816dd27b8f60f7fac1ac7626f57c9abacec77d147beb5da8401b86438b1591d93cae7f7511a3211cc01b3
+  languageName: node
+  linkType: hard
+
+"uint8arrays@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "uint8arrays@npm:3.1.1"
+  dependencies:
+    multiformats: ^9.4.2
+  checksum: b93b6c3f0a526b116799f3a3409bd4b5d5553eb3e73e485998ece7974742254fbc0d2f7988dd21ac86c4b974552f45d9ae9cf9cba9647e529f8eb1fdd2ed84d0
   languageName: node
   linkType: hard
 
@@ -16823,7 +17538,7 @@ __metadata:
     react-dom: ^18.2.0
     typescript: ^4.6.4
     vite: ^3.1.0
-    wagmi: ^0.9.0
+    wagmi: ^0.10.0
   languageName: unknown
   linkType: soft
 
@@ -16845,22 +17560,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "wagmi@npm:0.9.0"
+"wagmi@npm:^0.10.0":
+  version: 0.10.10
+  resolution: "wagmi@npm:0.10.10"
   dependencies:
     "@coinbase/wallet-sdk": ^3.6.0
     "@tanstack/query-sync-storage-persister": ^4.14.5
     "@tanstack/react-query": ^4.14.5
     "@tanstack/react-query-persist-client": ^4.14.5
-    "@wagmi/core": 0.8.0
+    "@wagmi/core": 0.8.14
     "@walletconnect/ethereum-provider": ^1.8.0
-    abitype: ^0.1.7
+    abitype: ^0.2.5
     use-sync-external-store: ^1.2.0
   peerDependencies:
     ethers: ">=5.5.1"
     react: ">=17.0.0"
-  checksum: 9cdde06cd3e0f45e7887fbda0f54f7236d0cd97fc4a677cc0d695b677d63cc9c0849263abbc804957808169dbd402ed354dc0e2b3724231d485b61a7c27b2412
+  checksum: a1a65ecab22f90b5382ac3e676e136e8889dbc377272792669be89dbad42d238f77e0957ac90c919ea54f45e03b24c3c240980a257a069e95be7ba383f4c39cd
   languageName: node
   linkType: hard
 
@@ -17537,7 +18252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.4.0, ws@npm:^7.4.5, ws@npm:^7.4.6":
+"ws@npm:^7.4.0, ws@npm:^7.4.5, ws@npm:^7.4.6, ws@npm:^7.5.1":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
   peerDependencies:
@@ -17731,9 +18446,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "zustand@npm:4.1.4"
+"zustand@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "zustand@npm:4.3.1"
   dependencies:
     use-sync-external-store: 1.2.0
   peerDependencies:
@@ -17744,6 +18459,6 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: a9ceb7849ebf407d31a6121be09acfb041324f6f45ca9a3f62ab85e2d840d0f48f157abd99ed7b9e08b96ebb4e15480b4a196ed8b1df8a5a9a2ba9afd7c639a7
+  checksum: bc35ebdfb2028e33d112ec113d77c95bdc3b693b3c2d78eacdc40017cf8f7f32934a49213aab3ee5e3767b44869bd306da171e6438b89fbc78417b419725e895
   languageName: node
   linkType: hard


### PR DESCRIPTION
Upgrade the `wagmi` peer dependency to `0.10.x`, which requires changes in the connector configurations
This does not include full support for WalletConnect 2.0

**release notes for wagmi 0.10.0**
https://github.com/wagmi-dev/wagmi/releases/tag/wagmi%400.10.0

