### PR TITLE
change: peer dependency wagmi to 0.10.x

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": "0.10.11"
+    "wagmi": "0.10.x"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",


### PR DESCRIPTION
this lets any version of wagmi's minor release version 10 be usable with connectkit