### PR TITLE
Add Nouns as optional fallback avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {
-    "@changesets/cli": "^2.24.4"
+    "@changesets/cli": "^2.24.4",
+    "@cloudnouns/kit": "^1.1.6"
   }
 }

--- a/packages/connectkit/src/components/Common/Avatar/index.tsx
+++ b/packages/connectkit/src/components/Common/Avatar/index.tsx
@@ -9,6 +9,8 @@ import useIsMounted from '../../../hooks/useIsMounted';
 
 type Hash = `0x${string}`;
 
+export type FallbackAvatar = 'gradient' | 'noun';
+
 export type CustomAvatarProps = {
   address?: Hash | undefined;
   ensName?: string | undefined;
@@ -48,6 +50,8 @@ const Avatar: React.FC<{
     avatar: ensAvatar ?? undefined,
   };
 
+  const fallbackAvatar = context.options?.fallbackAvatar;
+
   useEffect(() => {
     if (
       !(
@@ -86,12 +90,23 @@ const Avatar: React.FC<{
   if (!ens.name || !ens.avatar)
     return (
       <ResetContainer style={{ pointerEvents: 'none' }}>
-        <EnsAvatar $size={size} $seed={ens.address} $radius={radius} />
+        <EnsAvatar
+          $size={size}
+          $seed={ens.address}
+          $radius={radius}
+          $fallback={fallbackAvatar}
+        />
       </ResetContainer>
     );
+
   return (
     <ResetContainer style={{ pointerEvents: 'none' }}>
-      <EnsAvatar $size={size} $seed={ens.address} $radius={radius}>
+      <EnsAvatar
+        $size={size}
+        $seed={ens.address}
+        $radius={radius}
+        $fallback={fallbackAvatar}
+      >
         <ImageContainer
           ref={imageRef}
           src={ens.avatar}

--- a/packages/connectkit/src/components/Common/Avatar/styles.ts
+++ b/packages/connectkit/src/components/Common/Avatar/styles.ts
@@ -1,6 +1,8 @@
 import styled from './../../../styles/styled';
 import { css } from 'styled-components';
 import { motion } from 'framer-motion';
+import { FallbackAvatar } from '.';
+import { NounFactory } from '@cloudnouns/kit';
 
 function addressToNumber(address: string) {
   return (
@@ -17,6 +19,7 @@ export const EnsAvatar = styled(motion.div)<{
   $seed?: string;
   $size?: number;
   $radius?: number;
+  $fallback?: FallbackAvatar;
 }>`
   will-change: transform; // Needed for Safari
   pointer-events: none;
@@ -37,6 +40,19 @@ export const EnsAvatar = styled(motion.div)<{
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.02);
   }
   ${(props) => {
+    if (props.$fallback === 'noun') {
+      const noun = NounFactory.createFromString(props.$seed, {
+        size: 256,
+      });
+
+      return css`
+        background-image: url(${noun.url});
+        background-color: ${noun.background};
+        background-position: center;
+        background-size: cover;
+      `;
+    }
+
     if (props.$seed) {
       const id = Math.ceil(addressToNumber(props.$seed) * 8);
       const ensColor = `0${id === 0 ? 1 : id}`; // No zero ID in ENS color list.. 🤷‍♀️

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -22,6 +22,7 @@ import { useThemeFont } from '../hooks/useGoogleFont';
 import { useAccount, useNetwork } from 'wagmi';
 import { SIWEContext } from './Standard/SIWE/SIWEContext';
 import { getGlobalChains } from '../defaultClient';
+import { FallbackAvatar } from './Common/Avatar';
 
 export const routes = {
   ONBOARDING: 'onboarding',
@@ -75,6 +76,7 @@ type ConnectKitOptions = {
   disclaimer?: ReactNode | string;
   bufferPolyfill?: boolean;
   customAvatar?: React.FC<CustomAvatarProps>;
+  fallbackAvatar?: FallbackAvatar;
   initialChainId?: number;
   ethereumOnboardingUrl?: string;
   walletOnboardingUrl?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudnouns/kit@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@cloudnouns/kit@npm:1.1.6"
+  dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/solidity": ^5.7.0
+    jshashes: ^1.0.8
+  checksum: 2d5f2906c415886fba7975d119168fb4adf1fd069497c3deb48fc41cab2d7f67974bee17392ac7f318743a747b4e6b183b28ef8822a414bc2a33cc8c431f9e1f
+  languageName: node
+  linkType: hard
+
 "@coinbase/wallet-sdk@npm:^3.5.4":
   version: 3.6.3
   resolution: "@coinbase/wallet-sdk@npm:3.6.3"
@@ -2374,7 +2385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/solidity@npm:5.7.0":
+"@ethersproject/solidity@npm:5.7.0, @ethersproject/solidity@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/solidity@npm:5.7.0"
   dependencies:
@@ -9665,6 +9676,7 @@ __metadata:
   resolution: "family-connectkit@workspace:."
   dependencies:
     "@changesets/cli": ^2.24.4
+    "@cloudnouns/kit": ^1.1.6
     "@rollup/plugin-node-resolve": ^13.1.3
     ethers: ^5.6.5
     react: ^18.0.0
@@ -12110,6 +12122,15 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: b8b44cbfc92f198ad972fba706ee6a1dfa7485321ee8c0b25f5cedd538dcb20cde3197de16a7265430fce8277a12db066219369e3d51055038946039f6e20e17
+  languageName: node
+  linkType: hard
+
+"jshashes@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "jshashes@npm:1.0.8"
+  bin:
+    hashes: ./bin/hashes
+  checksum: 2fed89dc082a545d9dcdd38afb58aa7c74830cfdabcc836c9b4c52445d70f0217c4d2a4d42e6bbdb06f31bac3d1df385daff6beabbcc297a8ff5cca8f11c0bd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds optional `fallbackAvatar` to the `options` prop on `<ConnectKitProvider>`

Possible values are "gradient" (default) and "noun", which will generate a unique Noun using the connected address as a seed.

Vite implementation example:
```js
// main.tsx
root.render(
  <React.StrictMode>
    <WagmiConfig client={client}>
      <ConnectKitProvider
        options={{
          fallbackAvatar: 'noun',
        }}
      >
        <App />
      </ConnectKitProvider>
    </WagmiConfig>
  </React.StrictMode>
);
```