### PR TITLE
fix: sync dev/prod rollup configs (remove terser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.1.3
+
+This update fixes compatibility issues that were found with Next 13's default configuration. If you would like to use previous versions of ConnectKit you will need to make sure your application [supports Terser compression](https://nextjs.org/docs/advanced-features/compiler#minification).
+
+## Removed
+
+- Terser build compression.
+
+## Improved
+
+- Synced dev and prod rollup configs to avoid environment mismatching.
+- Next.js 13 config no longer requires Terser support ([`swcMinify: false`](https://nextjs.org/docs/advanced-features/compiler#minification)).
+
 # 1.1.2
 
 This update moves the peer dependency wagmi up to the latest version (`0.10.x`).
@@ -17,7 +30,6 @@ This does not yet include support for WalletConnect 2.0.
 - Update to chain handling to allow devs access to the configured chains using `getGlobalChains`.
 - Update to allow turning off the default targeted `chainId` to let wallets connect using their currently active chain.
 - - This can be done by setting `initialChainId` to `0` within the `getDefaultClient` helper function.
-
 
 # 1.1.1
 

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connectkit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Family",
   "homepage": "https://docs.family.co/connectkit",
   "license": "BSD-2-Clause license",

--- a/packages/connectkit/rollup.config.dev.js
+++ b/packages/connectkit/rollup.config.dev.js
@@ -14,6 +14,12 @@ export default [
         sourcemap: false,
       },
     ],
-    plugins: [peerDepsExternal(), typescript()],
+    plugins: [
+      peerDepsExternal(),
+      typescript({
+        useTsconfigDeclarationDir: true,
+        exclude: 'node_modules/**',
+      }),
+    ],
   },
 ];

--- a/packages/connectkit/rollup.config.prod.js
+++ b/packages/connectkit/rollup.config.prod.js
@@ -1,6 +1,5 @@
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import typescript from 'rollup-plugin-typescript2';
-import { terser } from 'rollup-plugin-terser';
 
 import packageJson from './package.json';
 
@@ -19,7 +18,6 @@ export default [
         useTsconfigDeclarationDir: true,
         exclude: 'node_modules/**',
       }),
-      terser(),
     ],
   },
 ];

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -8,7 +8,7 @@
       "@types/node": "^16.7.13",
       "@types/react": "^18.0.0",
       "@types/react-dom": "^18.0.0",
-      "connectkit": "^1.1.2",
+      "connectkit": "^1.1.3",
       "ethers": "^5.6.5",
       "typescript": "^4.4.2",
       "wagmi": "^0.10.11",


### PR DESCRIPTION
Terser minifying was only set up on the prod rollup config, this PR syncs the dev and prod configs more closely so we can avoid future app errors that aren't visible during the build process.

Terser doesn't seem to work with Next 13's default [`swcMinify: true`](https://nextjs.org/docs/advanced-features/compiler#minification) config setting, and they recommend setting this config to `false` if Terser is needed, but this is not something we should be requesting developers to change in their apps, so we need to remove Terser minifying on prod.

Fixes https://github.com/family/connectkit/issues/89