### PR TITLE
add: chain to custom connect button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Add `chain` to `ConnectKitButton.Custom` exports.
+
 # 1.1.2
 
 This update moves the peer dependency wagmi up to the latest version (`0.10.x`).
@@ -17,7 +19,6 @@ This does not yet include support for WalletConnect 2.0.
 - Update to chain handling to allow devs access to the configured chains using `getGlobalChains`.
 - Update to allow turning off the default targeted `chainId` to let wallets connect using their currently active chain.
 - - This can be done by setting `initialChainId` to `0` within the `getDefaultClient` helper function.
-
 
 # 1.1.1
 

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -245,7 +245,7 @@ const Home: NextPage = () => {
       </main>
       <aside>
         <ConnectKitButton.Custom>
-          {({ isConnected, show, address, ensName }) => {
+          {({ isConnected, show, address, ensName, chain }) => {
             return (
               <button onClick={show}>
                 {isConnected ? (
@@ -258,6 +258,8 @@ const Home: NextPage = () => {
                   >
                     <Avatar address={address} size={12} />
                     {ensName ?? address}
+                    {chain.name}
+                    <ChainIcon id={chain.id} unsupported={chain?.unsupported} />
                   </div>
                 ) : (
                   'Custom Connect'

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -256,10 +256,13 @@ const Home: NextPage = () => {
                       gap: 8,
                     }}
                   >
+                    {chain?.name}
+                    <ChainIcon
+                      id={chain?.id}
+                      unsupported={chain?.unsupported}
+                    />
                     <Avatar address={address} size={12} />
                     {ensName ?? address}
-                    {chain.name}
-                    <ChainIcon id={chain.id} unsupported={chain?.unsupported} />
                   </div>
                 ) : (
                   'Custom Connect'

--- a/packages/connectkit/src/components/ConnectButton/index.tsx
+++ b/packages/connectkit/src/components/ConnectButton/index.tsx
@@ -100,7 +100,9 @@ type ConnectButtonRendererProps = {
   children?: (renderProps: {
     show?: () => void;
     hide?: () => void;
-    chain?: Chain;
+    chain?: Chain & {
+      unsupported?: boolean;
+    };
     unsupported: boolean;
     isConnected: boolean;
     isConnecting: boolean;

--- a/packages/connectkit/src/components/ConnectButton/index.tsx
+++ b/packages/connectkit/src/components/ConnectButton/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAccount, useEnsName, useNetwork } from 'wagmi';
+import { Chain, useAccount, useEnsName, useNetwork } from 'wagmi';
 import { truncateENSAddress, truncateEthAddress } from './../../utils';
 import useIsMounted from '../../hooks/useIsMounted';
 
@@ -100,6 +100,7 @@ type ConnectButtonRendererProps = {
   children?: (renderProps: {
     show?: () => void;
     hide?: () => void;
+    chain?: Chain;
     unsupported: boolean;
     isConnected: boolean;
     isConnecting: boolean;
@@ -139,6 +140,7 @@ const ConnectButtonRenderer: React.FC<ConnectButtonRendererProps> = ({
       {children({
         show,
         hide,
+        chain: chain,
         unsupported: !!chain?.unsupported,
         isConnected: !!address,
         isConnecting: isConnecting,


### PR DESCRIPTION
This PR adds the currently connected chain to the exports for the `ConnectKitButton.Custom` component.