### PR TITLE
fix: metamask disconnect when switching network

### DIFF
--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -83,7 +83,7 @@ const getDefaultConnectors = ({
       chains,
       options: {
         shimDisconnect: true,
-        shimChainChangedDisconnect: false,
+        shimChainChangedDisconnect: true,
         UNSTABLE_shimOnConnectSelectAccount: true,
       },
     }),

--- a/packages/connectkit/src/wallets/connectors/metaMask.tsx
+++ b/packages/connectkit/src/wallets/connectors/metaMask.tsx
@@ -63,7 +63,7 @@ export const metaMask = ({ chains }: WalletOptions): WalletProps => {
             chains,
             options: {
               shimDisconnect: true,
-              shimChainChangedDisconnect: false,
+              shimChainChangedDisconnect: true,
               UNSTABLE_shimOnConnectSelectAccount: true,
             },
           });


### PR DESCRIPTION
I don't understand why [`shimChainChangedDisconnect `](https://wagmi.sh/react/connectors/metaMask#shimchainchangeddisconnect) is disabled. This flag prevents a bug in metamask where switching network will result in disconnecting. It should be enabled.

This metamask bug only happens when switching from a default network to a custom network. Please refer to [this](https://github.com/wagmi-dev/wagmi/issues/1239#issuecomment-1304660937).