### PR TITLE
update: walletconnect v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.0
 
-This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`>=0.11.4`) to support WalletConnect v2.
+This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`>=0.11.5) to support WalletConnect v2.
 
 {% note %}
 This version of ConnectKit has breaking changes. Make sure your application is compatible by following the [migration guide (TODO: Get link to migration guide)](https://docs.family.co/connectkit/migration-guides).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.2.0
+
+This update moves the peer dependency [wagmi](https://wagmi.sh) up to the latest version (`>=0.11.4`) to support WalletConnect v2.
+
+{% note %}
+This version of ConnectKit has breaking changes. Make sure your application is compatible by following the [migration guide (TODO: Get link to migration guide)](https://docs.family.co/connectkit/migration-guides).
+{% endnote %}
+
+## Improved
+
+- WalletConnect v2 support.
+- Refactored wallet connectors to be more extensible.
+- Replaced `getGlobalChains` with `useChains` hook that syncs better with configured connectors.
+- Added `useConnectors` hook to access the above connectors if necessary.
+- Export `useIsMounted` for developers to not have to provide their own solution.
+-
+
 # 1.1.3
 
 This update fixes compatibility issues that were found with Next 13's default configuration. If you would like to use previous versions of ConnectKit you will need to make sure your application [supports Terser compression](https://nextjs.org/docs/advanced-features/compiler#minification).

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -11,12 +11,12 @@
     "@types/react": "^18.0.20",
     "@types/react-dom": "^18.0.6",
     "connectkit": "workspace:packages/connectkit",
-    "ethers": "^5.6.5",
+    "ethers": "^5.7.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "wagmi": "^0.11.4",
+    "wagmi": "^0.11.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -15,8 +15,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.8.3",
-    "wagmi": "^0.10.11",
+    "typescript": "^4.9.5",
+    "wagmi": "^0.11.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "wagmi": "^0.11.3",
+    "wagmi": "^0.11.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,7 +14,7 @@
     "next": "12.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.11"
+    "wagmi": "^0.11.3"
   },
   "devDependencies": {
     "@types/node": "18.7.18",
@@ -22,6 +22,6 @@
     "@types/react-dom": "^18.0.2",
     "eslint": "8.23.1",
     "eslint-config-next": "12.3.0",
-    "typescript": "4.8.3"
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -14,7 +14,7 @@
     "next": "12.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.3"
+    "wagmi": "^0.11.4"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "connectkit": "workspace:packages/connectkit",
-    "ethers": "^5.6.5",
+    "ethers": "^5.7.1",
     "next": "12.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.4"
+    "wagmi": "^0.11.5"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -16,7 +16,7 @@
     "next": "13.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.11"
+    "wagmi": "^0.11.3"
   },
   "devDependencies": {
     "@types/node": "18.7.18",
@@ -24,6 +24,6 @@
     "@types/react-dom": "^18.0.2",
     "eslint": "8.23.1",
     "eslint-config-next": "12.3.0",
-    "typescript": "4.8.3"
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -16,7 +16,7 @@
     "next": "13.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.3"
+    "wagmi": "^0.11.4"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/package.json
+++ b/examples/testbench/package.json
@@ -11,12 +11,12 @@
   "dependencies": {
     "connectkit": "workspace:packages/connectkit",
     "connectkit-next-siwe": "workspace:packages/connectkit-next-siwe",
-    "ethers": "^5.6.5",
+    "ethers": "^5.7.1",
     "local-ssl-proxy": "^1.3.0",
     "next": "13.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.4"
+    "wagmi": "^0.11.5"
   },
   "devDependencies": {
     "@types/node": "18.7.18",

--- a/examples/testbench/src/TestbenchProvider.tsx
+++ b/examples/testbench/src/TestbenchProvider.tsx
@@ -49,7 +49,7 @@ export const TestBenchProvider: React.FC<TestBenchProviderProps> = ({
     reducedMotion: false,
     disclaimer: null,
     bufferPolyfill: true,
-    walletConnectCTA: 'modal',
+    walletConnectCTA: 'link',
     //initialChainId: 0,
   },
 }) => {

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -52,10 +52,6 @@ function MyApp(appProps: AppProps) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
-        <link
-          href="https://fonts.cdnfonts.com/css/pt-root-ui"
-          rel="stylesheet"
-        />
       </Head>
       <WagmiConfig client={client}>
         <TestBenchProvider

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -67,10 +67,10 @@ function MyApp(appProps: AppProps) {
         >
           <div style={{ position: 'absolute', top: 0, right: 0 }}>
             <button onClick={() => setVersion('1')} disabled={version === '1'}>
-              Use WalletConnect V1
+              Use WalletConnect V1 {version === '1' && '(active)'}
             </button>
             <button onClick={() => setVersion('2')} disabled={version === '2'}>
-              Use WalletConnect V2
+              Use WalletConnect V2 {version === '2' && '(active)'}
             </button>
           </div>
           <App {...appProps} />

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -15,13 +15,11 @@ const client = createClient(
     appIcon: '/app.png',
     infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
     alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
-    // WalletConnect 2.0 coming soon
-    /*
+    // WalletConnect 2.0
     walletConnectOptions: {
       version: '2',
       projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
     },
-    */
   })
 );
 

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -29,7 +29,7 @@ function App({ Component, pageProps }: AppProps) {
   );
 }
 function MyApp(appProps: AppProps) {
-  const [version, setVersion] = useState('1');
+  const [version, setVersion] = useState('2');
 
   const client = createClient(
     getDefaultClient({

--- a/examples/testbench/src/pages/_app.tsx
+++ b/examples/testbench/src/pages/_app.tsx
@@ -7,21 +7,7 @@ import { mainnet, polygon } from 'wagmi/chains';
 import { ConnectKitProvider, getDefaultClient } from 'connectkit';
 import { TestBenchProvider, useTestBench } from '../TestbenchProvider';
 import { siwe } from '../siwe';
-
-const client = createClient(
-  getDefaultClient({
-    //chains: [mainnet, polygon],
-    appName: 'ConnectKit testbench',
-    appIcon: '/app.png',
-    infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
-    alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
-    // WalletConnect 2.0
-    walletConnectOptions: {
-      version: '2',
-      projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
-    },
-  })
-);
+import { useState } from 'react';
 
 function App({ Component, pageProps }: AppProps) {
   const { theme, mode, options, customTheme } = useTestBench();
@@ -43,6 +29,28 @@ function App({ Component, pageProps }: AppProps) {
   );
 }
 function MyApp(appProps: AppProps) {
+  const [version, setVersion] = useState('1');
+
+  const client = createClient(
+    getDefaultClient({
+      //chains: [mainnet, polygon],
+      appName: 'ConnectKit testbench',
+      appIcon: '/app.png',
+      infuraId: process.env.NEXT_PUBLIC_INFURA_ID,
+      alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_ID,
+      // WalletConnect 2.0
+      walletConnectOptions:
+        version === '1'
+          ? {
+              version: '1',
+            }
+          : {
+              version: '2',
+              projectId: process.env
+                .NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
+            },
+    })
+  );
   return (
     <>
       <Head>
@@ -57,6 +65,14 @@ function MyApp(appProps: AppProps) {
         <TestBenchProvider
         //customTheme={{ '--ck-font-family': 'monospace' }}
         >
+          <div style={{ position: 'absolute', top: 0, right: 0 }}>
+            <button onClick={() => setVersion('1')} disabled={version === '1'}>
+              Use WalletConnect V1
+            </button>
+            <button onClick={() => setVersion('2')} disabled={version === '2'}>
+              Use WalletConnect V2
+            </button>
+          </div>
           <App {...appProps} />
         </TestBenchProvider>
       </WagmiConfig>

--- a/examples/testbench/src/pages/_document.tsx
+++ b/examples/testbench/src/pages/_document.tsx
@@ -34,6 +34,10 @@ export default class CustomDocument extends Document {
       <Html>
         <Head>
           <link rel="icon" href="https://family.co/favicon.png" />
+          <link
+            href="https://fonts.cdnfonts.com/css/pt-root-ui"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -22,6 +22,8 @@ import {
   useSignMessage,
   useSignTypedData,
   usePrepareSendTransaction,
+  useConnect,
+  useDisconnect,
 } from 'wagmi';
 import { Chain } from 'wagmi/chains';
 
@@ -236,6 +238,21 @@ const Home: NextPage = () => {
 
   const { chain } = useNetwork();
   const chains = useChains();
+  const { connectors, reset } = useConnect();
+  const { isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
+
+  const WCV2 =
+    connectors.find((c) => c.id === 'walletConnect')?.options?.version === '2';
+
+  const handleDisconnect = () => {
+    disconnect();
+    reset();
+  };
+
+  useEffect(() => {
+    if (WCV2) handleDisconnect();
+  }, [WCV2]);
 
   if (!mounted) return null;
 
@@ -244,6 +261,8 @@ const Home: NextPage = () => {
       <main>
         <p>Connect Button</p>
         <ConnectKitButton label={label} />
+
+        {isConnected && <button onClick={handleDisconnect}>Disconnect</button>}
 
         <hr />
         <p>Sign In With Ethereum</p>
@@ -305,7 +324,7 @@ const Home: NextPage = () => {
           }}
         </ConnectKitButton.Custom>
 
-        <Actions />
+        {!WCV2 && <Actions />}
         <h2>ConnectKitButton props</h2>
         <Textbox
           label="ConnectKitButton Label"

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -1,4 +1,9 @@
 import type { NextPage } from 'next';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { BigNumber } from 'ethers';
+
 import {
   ConnectKitButton,
   Types,
@@ -6,10 +11,9 @@ import {
   useSIWE,
   SIWEButton,
   ChainIcon,
-  getGlobalChains,
+  useChains,
 } from 'connectkit';
-import { useTestBench } from '../TestbenchProvider';
-import { Checkbox, Textbox, Select, SelectProps } from '../components/inputs';
+
 import {
   useAccount,
   useBalance,
@@ -19,10 +23,10 @@ import {
   useSignTypedData,
   usePrepareSendTransaction,
 } from 'wagmi';
-import { useEffect, useState } from 'react';
-import { BigNumber } from 'ethers';
-import Link from 'next/link';
+import { Chain } from 'wagmi/chains';
 
+import { useTestBench } from '../TestbenchProvider';
+import { Checkbox, Textbox, Select, SelectProps } from '../components/inputs';
 import CustomAvatar from '../components/CustomAvatar';
 
 /** TODO: import this data from the connectkit module */
@@ -199,7 +203,7 @@ const Home: NextPage = () => {
   useEffect(() => setMounted(true), []);
 
   const { chain } = useNetwork();
-  const chains = getGlobalChains();
+  const chains = useChains();
 
   if (!mounted) return null;
 
@@ -238,7 +242,7 @@ const Home: NextPage = () => {
         </div>
         <p>Supported Chains</p>
         <div style={{ display: 'flex', gap: 8 }}>
-          {chains.map((chain) => (
+          {chains.map((chain: Chain) => (
             <ChainIcon key={chain.id} id={chain.id} />
           ))}
         </div>

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -56,59 +56,72 @@ const languages: SelectProps[] = [
 ];
 
 const AccountInfo = () => {
-  const { address, connector } = useAccount();
+  const {
+    address,
+    connector,
+    isConnected,
+    isConnecting,
+    isDisconnected,
+    isReconnecting,
+  } = useAccount();
   const { data: balanceData } = useBalance({ address });
   const { chain } = useNetwork();
   const siwe = useSIWE();
 
   return (
-    <>
-      <table>
-        <tbody>
-          <tr>
-            <td>Chain ID</td>
-            <td>{chain?.id}</td>
-          </tr>
-          <tr>
-            <td>Chain Name</td>
-            <td>{chain?.name}</td>
-          </tr>
-          <tr>
-            <td>Chain Supported</td>
-            <td>{!chain || chain?.unsupported ? 'No' : 'Yes'}</td>
-          </tr>
-          <tr>
-            <td>Address</td>
-            <td>{address}</td>
-          </tr>
-          <tr>
-            <td>Balance</td>
-            <td>{balanceData?.formatted}</td>
-          </tr>
-          <tr>
-            <td>Connector</td>
-            <td>{connector?.id}</td>
-          </tr>
-          <tr>
-            <td>Connector Version</td>
-            <td>{connector?.options?.version}</td>
-          </tr>
-          <tr>
-            <td>WalletConnect Project ID</td>
-            <td>{connector?.options?.projectId}</td>
-          </tr>
-          <tr>
-            <td>SIWE session</td>
-            <td>
-              {siwe.signedIn ? 'yes' : 'no'}{' '}
-              {siwe.signedIn && (
-                <button onClick={siwe.signOut}>sign out</button>
-              )}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </>
+    <div className="panel">
+      <h2>Wallet Info</h2>
+      {isConnecting && <p>Connecting...</p>}
+      {isReconnecting && <p>Reconnecting...</p>}
+      {isDisconnected && <p>Disconnected</p>}
+      {isConnected && (
+        <table>
+          <tbody>
+            <tr>
+              <td>Chain ID</td>
+              <td>{chain?.id}</td>
+            </tr>
+            <tr>
+              <td>Chain Name</td>
+              <td>{chain?.name}</td>
+            </tr>
+            <tr>
+              <td>Chain Supported</td>
+              <td>{!chain || chain?.unsupported ? 'No' : 'Yes'}</td>
+            </tr>
+            <tr>
+              <td>Address</td>
+              <td>{address}</td>
+            </tr>
+            <tr>
+              <td>Balance</td>
+              <td>{balanceData?.formatted}</td>
+            </tr>
+            <tr>
+              <td>Connector</td>
+              <td>{connector?.id}</td>
+            </tr>
+            <tr>
+              <td>Connector Version</td>
+              <td>{connector?.options?.version}</td>
+            </tr>
+            <tr>
+              <td>WalletConnect Project ID</td>
+              <td>{connector?.options?.projectId}</td>
+            </tr>
+            <tr>
+              <td>SIWE session</td>
+              <td>
+                {siwe.signedIn ? 'yes' : 'no'}{' '}
+                {siwe.signedIn && (
+                  <button onClick={siwe.signOut}>sign out</button>
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+    </div>
   );
 };
 
@@ -250,54 +263,54 @@ const Home: NextPage = () => {
     reset();
   };
 
-  useEffect(() => {
-    if (WCV2) handleDisconnect();
-  }, [WCV2]);
-
   if (!mounted) return null;
 
   return (
     <>
       <main>
-        <p>Connect Button</p>
-        <ConnectKitButton label={label} />
+        <div className="panel">
+          <h2>Connect Button</h2>
+          <ConnectKitButton label={label} />
+          {isConnected && (
+            <button onClick={handleDisconnect}>Disconnect</button>
+          )}
+        </div>
 
-        {isConnected && <button onClick={handleDisconnect}>Disconnect</button>}
+        <div className="panel">
+          <h2>Sign In With Ethereum</h2>
+          <SIWEButton showSignOutButton />
+          <Link href="/siwe/token-gated">Token-gated page &rarr;</Link>
+        </div>
 
-        <hr />
-        <p>Sign In With Ethereum</p>
-        <SIWEButton showSignOutButton />
-
-        <Link href="/siwe/token-gated">Token-gated page &rarr;</Link>
-
-        <hr />
         <AccountInfo />
 
-        <hr />
-        <p>Avatars</p>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <Avatar name="lochie.eth" />
-          <Avatar name="pugson.eth" size={32} />
-          <Avatar
-            address="0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-            size={12}
-          />
-          <Avatar name="benjitaylor.eth" size={64} />
+        <div className="panel">
+          <h2>Chains</h2>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <ChainIcon id={chain?.id} unsupported={chain?.unsupported} />
+            <ChainIcon id={1} />
+            <ChainIcon id={1337} />
+            <ChainIcon id={2} unsupported />
+          </div>
+          <h2>dApps configured chains</h2>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {chains.map((chain: Chain) => (
+              <ChainIcon key={chain.id} id={chain.id} />
+            ))}
+          </div>
         </div>
 
-        <hr />
-        <p>Chains</p>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <ChainIcon id={chain?.id} unsupported={chain?.unsupported} />
-          <ChainIcon id={1} />
-          <ChainIcon id={1337} />
-          <ChainIcon id={2} unsupported />
-        </div>
-        <p>Supported Chains</p>
-        <div style={{ display: 'flex', gap: 8 }}>
-          {chains.map((chain: Chain) => (
-            <ChainIcon key={chain.id} id={chain.id} />
-          ))}
+        <div className="panel">
+          <h2>Avatars</h2>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Avatar name="lochie.eth" />
+            <Avatar name="pugson.eth" size={32} radius={6} />
+            <Avatar
+              address="0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              size={12}
+            />
+            <Avatar name="benjitaylor.eth" size={64} />
+          </div>
         </div>
       </main>
       <aside>

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -60,21 +60,53 @@ const AccountInfo = () => {
   const siwe = useSIWE();
 
   return (
-    <ul>
-      <li>ChainID: {chain?.id}</li>
-      <li>Chain name: {chain?.name}</li>
-      <li>Chain Supported: {chain?.unsupported ? 'No' : 'Yes'}</li>
-      <li>Address: {address}</li>
-      <li>Connector: {connector?.id}</li>
-      <li>Balance: {balanceData?.formatted}</li>
-      <li>
-        SIWE session: {siwe.signedIn ? 'yes' : 'no'}
-        {siwe.signedIn && <button onClick={siwe.signOut}>sign out</button>}
-      </li>
-      <li>
-        <Link href="/siwe/token-gated">Token-gated page</Link>
-      </li>
-    </ul>
+    <>
+      <table>
+        <tbody>
+          <tr>
+            <td>Chain ID</td>
+            <td>{chain?.id}</td>
+          </tr>
+          <tr>
+            <td>Chain Name</td>
+            <td>{chain?.name}</td>
+          </tr>
+          <tr>
+            <td>Chain Supported</td>
+            <td>{!chain || chain?.unsupported ? 'No' : 'Yes'}</td>
+          </tr>
+          <tr>
+            <td>Address</td>
+            <td>{address}</td>
+          </tr>
+          <tr>
+            <td>Balance</td>
+            <td>{balanceData?.formatted}</td>
+          </tr>
+          <tr>
+            <td>Connector</td>
+            <td>{connector?.id}</td>
+          </tr>
+          <tr>
+            <td>Connector Version</td>
+            <td>{connector?.options?.version}</td>
+          </tr>
+          <tr>
+            <td>WalletConnect Project ID</td>
+            <td>{connector?.options?.projectId}</td>
+          </tr>
+          <tr>
+            <td>SIWE session</td>
+            <td>
+              {siwe.signedIn ? 'yes' : 'no'}{' '}
+              {siwe.signedIn && (
+                <button onClick={siwe.signOut}>sign out</button>
+              )}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
   );
 };
 
@@ -216,6 +248,8 @@ const Home: NextPage = () => {
         <hr />
         <p>Sign In With Ethereum</p>
         <SIWEButton showSignOutButton />
+
+        <Link href="/siwe/token-gated">Token-gated page &rarr;</Link>
 
         <hr />
         <AccountInfo />

--- a/examples/testbench/src/styles/globals.css
+++ b/examples/testbench/src/styles/globals.css
@@ -13,18 +13,18 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: 12px;
 }
-main label {
+aside label {
   display: flex;
   width: auto;
   padding: 0 0 8px;
 }
-main label.checkbox {
+aside label.checkbox {
   align-items: center;
   gap: 4px;
 }
 
-main label.textbox,
-main label.select {
+aside label.textbox,
+aside label.select {
   flex-direction: column;
   gap: 2px;
 }

--- a/examples/testbench/src/styles/globals.css
+++ b/examples/testbench/src/styles/globals.css
@@ -13,25 +13,59 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: 12px;
 }
-label {
+main label {
   display: flex;
   width: auto;
   padding: 0 0 8px;
 }
-label.checkbox {
+main label.checkbox {
   align-items: center;
   gap: 4px;
 }
 
-label.textbox,
-label.select {
+main label.textbox,
+main label.select {
   flex-direction: column;
   gap: 2px;
+}
+
+main button {
+  display: inline-block;
+  width: fit-content;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #fff;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+main .panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 4%);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+}
+main table tr:nth-child(odd) {
+  background: rgba(0, 0, 0, 0.05);
+}
+main table td {
+  padding: 4px 8px;
+}
+main table td:first-child {
+  font-weight: bold;
 }
 
 main {
   padding: 32px;
   padding-left: 352px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(512px, 1fr));
+  grid-gap: 32px;
 }
 aside {
   z-index: 2147483647;

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "connectkit": "workspace:packages/connectkit",
-    "ethers": "^5.6.5",
+    "ethers": "^5.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.11.4"
+    "wagmi": "^0.11.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -13,7 +13,7 @@
     "ethers": "^5.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.11.3"
+    "wagmi": "^0.11.4"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -13,13 +13,13 @@
     "ethers": "^5.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.10.11"
+    "wagmi": "^0.11.3"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.1.0",
-    "typescript": "^4.6.4",
+    "typescript": "^4.9.5",
     "vite": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "ethers": "^5.6.5",
+    "ethers": "^5.7.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "rollup": "^2.67.1",
@@ -35,7 +35,7 @@
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",
     "tslib": "^1.9.3",
-    "wagmi": "^0.11.4"
+    "wagmi": "^0.11.5"
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",
     "tslib": "^1.9.3",
-    "wagmi": "^0.11.3"
+    "wagmi": "^0.11.4"
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",
     "tslib": "^1.9.3",
-    "wagmi": "^0.10.11"
+    "wagmi": "^0.11.3"
   },
   "packageManager": "yarn@3.2.0",
   "dependencies": {

--- a/packages/connectkit-next-siwe/package.json
+++ b/packages/connectkit-next-siwe/package.json
@@ -50,6 +50,6 @@
     "@types/node": "^16.11.27",
     "@types/react": "^18.0.6",
     "@types/react-dom": "^18.0.2",
-    "typescript": "^4.6.3"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": ">=0.11.4"
+    "wagmi": ">=0.11.5"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",
@@ -62,6 +62,6 @@
   "resolutions": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.4"
+    "wagmi": "^0.11.5"
   }
 }

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": "0.10.x"
+    "wagmi": ">=0.11.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",
@@ -57,11 +57,11 @@
     "@types/react": "^18.0.6",
     "@types/react-dom": "^18.0.2",
     "@types/styled-components": "^5.1.25",
-    "typescript": "^4.6.3"
+    "typescript": "^4.9.5"
   },
   "resolutions": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.10.11"
+    "wagmi": "^0.11.3"
   }
 }

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -49,7 +49,7 @@
     "ethers": ">=5.5.0 <6",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",
-    "wagmi": ">=0.11.3"
+    "wagmi": ">=0.11.4"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",
@@ -62,6 +62,6 @@
   "resolutions": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "wagmi": "^0.11.3"
+    "wagmi": "^0.11.4"
   }
 }

--- a/packages/connectkit/src/components/Common/Button/styles.ts
+++ b/packages/connectkit/src/components/Common/Button/styles.ts
@@ -76,6 +76,9 @@ export const ButtonContainer = styled.button<{
     css`
       cursor: not-allowed;
       pointer-events: none;
+      ${InnerContainer} {
+        opacity: 0.4;
+      }
     `}
 
   ${({ $variant }) => {
@@ -265,6 +268,7 @@ export const InnerContainer = styled.div`
   display: inline-block;
   vertical-align: middle;
   max-width: calc(100% - 42px);
+  transition: opacity 300ms ease;
   /*
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -104,6 +104,7 @@ const ChainSelectList: React.FC = () => {
                       transition={{
                         ease: [0.76, 0, 0.24, 1],
                         duration: 0.15,
+                        delay: 0.1,
                       }}
                     >
                       <motion.div
@@ -175,6 +176,7 @@ const ChainSelectList: React.FC = () => {
                         transition={{
                           ease: [0.76, 0, 0.24, 1],
                           duration: 0.3,
+                          delay: 0.1,
                         }}
                       >
                         <motion.span

--- a/packages/connectkit/src/components/Common/CopyToClipboard/index.tsx
+++ b/packages/connectkit/src/components/Common/CopyToClipboard/index.tsx
@@ -74,6 +74,7 @@ const CopyToClipboard: React.FC<{
     return (
       <Button
         disabled={!string}
+        waiting={!string}
         onClick={onCopy}
         icon={<CopyToClipboardIcon copied={clipboard} />}
       >

--- a/packages/connectkit/src/components/Common/CopyToClipboard/index.tsx
+++ b/packages/connectkit/src/components/Common/CopyToClipboard/index.tsx
@@ -74,7 +74,6 @@ const CopyToClipboard: React.FC<{
     return (
       <Button
         disabled={!string}
-        waiting={!string}
         onClick={onCopy}
         icon={<CopyToClipboardIcon copied={clipboard} />}
       >

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -49,7 +49,7 @@ const CustomQRCode = React.forwardRef(
             </LogoContainer>
           )}
 
-          <AnimatePresence initial={false}>
+          <AnimatePresence initial={!value}>
             {value ? (
               <motion.div
                 key={value}
@@ -69,12 +69,12 @@ const CustomQRCode = React.forwardRef(
               </motion.div>
             ) : (
               <QRPlaceholder
-                initial={{ opacity: 0 }}
+                initial={{ opacity: 0.1 }}
                 animate={{ opacity: 0.1 }}
                 exit={{ opacity: 0, position: 'absolute', inset: [0, 0] }}
                 transition={{
-                  delay: !value ? 0.4 : 0,
-                  duration: 0.4,
+                  delay: !value ? 0.2 : 0,
+                  duration: 0.2,
                 }}
               >
                 <span />

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -58,6 +58,7 @@ const CustomQRCode = React.forwardRef(
                 exit={{ opacity: 0, position: 'absolute', inset: [0, 0] }}
                 transition={{
                   duration: 0.4,
+                  delay: 0.1,
                 }}
               >
                 <QRCode
@@ -73,8 +74,7 @@ const CustomQRCode = React.forwardRef(
                 animate={{ opacity: 0.1 }}
                 exit={{ opacity: 0, position: 'absolute', inset: [0, 0] }}
                 transition={{
-                  delay: !value ? 0.2 : 0,
-                  duration: 0.2,
+                  duration: 0.15,
                 }}
               >
                 <span />

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -49,8 +49,8 @@ const CustomQRCode = React.forwardRef(
             </LogoContainer>
           )}
 
-          {value ? (
-            <AnimatePresence initial={false}>
+          <AnimatePresence initial={!value}>
+            {value ? (
               <motion.div
                 key={value}
                 initial={{ opacity: 0 }}
@@ -67,10 +67,18 @@ const CustomQRCode = React.forwardRef(
                   clearArea={!!(imagePosition === 'center' && image)}
                 />
               </motion.div>
-            </AnimatePresence>
-          ) : (
-            <QRPlaceholder />
-          )}
+            ) : (
+              <QRPlaceholder
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0, position: 'absolute', inset: [0, 0] }}
+                transition={{
+                  delay: !value ? 0.4 : 0,
+                  duration: 0.4,
+                }}
+              />
+            )}
+          </AnimatePresence>
         </QRCodeContent>
       </QRCodeContainer>
     );

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -49,7 +49,7 @@ const CustomQRCode = React.forwardRef(
             </LogoContainer>
           )}
 
-          <AnimatePresence initial={!value}>
+          <AnimatePresence initial={false}>
             {value ? (
               <motion.div
                 key={value}
@@ -70,13 +70,17 @@ const CustomQRCode = React.forwardRef(
             ) : (
               <QRPlaceholder
                 initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
+                animate={{ opacity: 0.1 }}
                 exit={{ opacity: 0, position: 'absolute', inset: [0, 0] }}
                 transition={{
                   delay: !value ? 0.4 : 0,
                   duration: 0.4,
                 }}
-              />
+              >
+                <span />
+                <span />
+                <span />
+              </QRPlaceholder>
             )}
           </AnimatePresence>
         </QRCodeContent>

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -12,6 +12,7 @@ import Tooltip from '../Tooltip';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { QRCode } from './QRCode';
+import useWindowSize from '../../../hooks/useWindowSize';
 
 const CustomQRCode = React.forwardRef(
   (
@@ -24,13 +25,15 @@ const CustomQRCode = React.forwardRef(
     }: CustomQRCodeProps,
     ref: React.Ref<HTMLElement>
   ) => {
-    const Logo = tooltipMessage ? (
-      <Tooltip xOffset={139} yOffset={5} delay={0.1} message={tooltipMessage}>
-        {image}
-      </Tooltip>
-    ) : (
-      image
-    );
+    const windowSize = useWindowSize();
+    const Logo =
+      windowSize.width > 920 && tooltipMessage ? (
+        <Tooltip xOffset={139} yOffset={5} delay={0.1} message={tooltipMessage}>
+          {image}
+        </Tooltip>
+      ) : (
+        image
+      );
 
     return (
       <QRCodeContainer>

--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -80,6 +80,7 @@ const CustomQRCode = React.forwardRef(
                 <span />
                 <span />
                 <span />
+                <div />
               </QRPlaceholder>
             )}
           </AnimatePresence>

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -41,7 +41,6 @@ export const QRPlaceholder = styled(motion.div)`
   display: flex;
   align-items: center;
   justify-content: center;
-  /*
   &:before {
     z-index: 4;
     content: '';
@@ -58,7 +57,6 @@ export const QRPlaceholder = styled(motion.div)`
     background-size: 200% 100%;
     animation: ${PlaceholderKeyframes} 1000ms linear infinite both;
   }
-  */
 `;
 
 export const LogoContainer = styled(motion.div)`

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -36,12 +36,50 @@ export const PlaceholderKeyframes = keyframes`
   100%{ background-position: -100% 0; }
 `;
 export const QRPlaceholder = styled(motion.div)`
+  --color: var(--ck-qr-dot-color);
+  --bg: var(--ck-qr-background, var(--ck-body-background));
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  opacity: 0.3;
+  span {
+    z-index: 5;
+    position: absolute;
+    background: var(--color);
+    border-radius: 9px;
+    width: 13.5%;
+    height: 13.5%;
+    box-shadow: 0 0 0 3px var(--bg), 0 0 0 7px var(--bg);
+    &:before {
+      content: '';
+      position: absolute;
+      inset: 8px;
+      border-radius: 3px;
+      background: inherit;
+      box-shadow: 0 0 0 5px var(--bg);
+    }
+    &:nth-child(1) {
+      top: 0;
+      left: 0;
+    }
+    &:nth-child(2) {
+      top: 0;
+      right: 0;
+    }
+    &:nth-child(3) {
+      bottom: 0;
+      left: 0;
+    }
+  }
   &:before {
+    z-index: 3;
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeat;
+    background-size: 2% 2%;
+    background-image: radial-gradient(var(--color) 40%, transparent 40%);
+  }
+  &:after {
     z-index: 4;
     content: '';
     position: absolute;
@@ -50,10 +88,9 @@ export const QRPlaceholder = styled(motion.div)`
     background-image: linear-gradient(
       90deg,
       rgba(255, 255, 255, 0) 50%,
-      rgba(0, 0, 0, 0.05),
+      rgba(255, 255, 255, 1),
       rgba(255, 255, 255, 0)
     );
-    opacity: 0.75;
     background-size: 200% 100%;
     animation: ${PlaceholderKeyframes} 1000ms linear infinite both;
   }

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -38,6 +38,7 @@ export const PlaceholderKeyframes = keyframes`
 export const QRPlaceholder = styled(motion.div)`
   --color: var(--ck-qr-dot-color);
   --bg: var(--ck-qr-background, var(--ck-body-background));
+
   position: absolute;
   inset: 0;
   display: flex;
@@ -56,17 +57,16 @@ export const QRPlaceholder = styled(motion.div)`
     z-index: 4;
     position: absolute;
     background: var(--color);
-    border-radius: 9px;
-    width: 13.5%;
-    height: 13.5%;
-    box-shadow: 0 0 0 3px var(--bg), 0 0 0 7px var(--bg);
+    border-radius: 12px;
+    width: 13.25%;
+    height: 13.25%;
+    box-shadow: 0 0 0 4px var(--bg);
     &:before {
       content: '';
       position: absolute;
-      inset: 8px;
+      inset: 9px;
       border-radius: 3px;
-      background: inherit;
-      box-shadow: 0 0 0 5px var(--bg);
+      box-shadow: 0 0 0 4px var(--bg);
     }
     &:nth-child(1) {
       top: 0;
@@ -87,7 +87,7 @@ export const QRPlaceholder = styled(motion.div)`
     position: absolute;
     inset: 0;
     background: repeat;
-    background-size: 2% 2%;
+    background-size: 1.888% 1.888%;
     background-image: radial-gradient(var(--color) 40%, transparent 40%);
   }
   &:after {

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -40,9 +40,8 @@ export const QRPlaceholder = styled(motion.div)`
   --bg: var(--ck-qr-background, var(--ck-body-background));
   position: absolute;
   inset: 0;
-  opacity: 0.3;
   span {
-    z-index: 5;
+    z-index: 4;
     position: absolute;
     background: var(--color);
     border-radius: 9px;
@@ -80,7 +79,7 @@ export const QRPlaceholder = styled(motion.div)`
     background-image: radial-gradient(var(--color) 40%, transparent 40%);
   }
   &:after {
-    z-index: 4;
+    z-index: 5;
     content: '';
     position: absolute;
     inset: 0;

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -88,7 +88,7 @@ export const QRPlaceholder = styled(motion.div)`
     inset: 0;
     background: repeat;
     background-size: 1.888% 1.888%;
-    background-image: radial-gradient(var(--color) 40%, transparent 40%);
+    background-image: radial-gradient(var(--color) 41%, transparent 41%);
   }
   &:after {
     z-index: 5;

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -50,7 +50,7 @@ export const QRPlaceholder = styled(motion.div)`
     background-image: linear-gradient(
       90deg,
       rgba(255, 255, 255, 0) 50%,
-      rgba(0, 0, 0, 0.1),
+      rgba(0, 0, 0, 0.05),
       rgba(255, 255, 255, 0)
     );
     opacity: 0.75;

--- a/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
+++ b/packages/connectkit/src/components/Common/CustomQRCode/styles.ts
@@ -40,7 +40,19 @@ export const QRPlaceholder = styled(motion.div)`
   --bg: var(--ck-qr-background, var(--ck-body-background));
   position: absolute;
   inset: 0;
-  span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  > div {
+    z-index: 4;
+    position: relative;
+    width: 28%;
+    height: 28%;
+    border-radius: 20px;
+    background: var(--bg);
+    box-shadow: 0 0 0 7px var(--bg);
+  }
+  > span {
     z-index: 4;
     position: absolute;
     background: var(--color);

--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -428,6 +428,7 @@ const Modal: React.FC<ModalProps> = ({
                       position: 'absolute',
                       right: 24,
                       top: 24,
+                      cursor: 'pointer',
                     }}
                   >
                     <CloseIcon />

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -109,7 +109,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     hideTooltips: false,
     hideQuestionMarkCTA: false,
     hideNoWalletCTA: false,
-    walletConnectCTA: 'modal',
+    walletConnectCTA: 'link',
     avoidLayoutShift: true,
     embedGoogleFonts: false,
     truncateLongENSAddress: true,

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -21,7 +21,7 @@ import { ThemeProvider } from 'styled-components';
 import { useThemeFont } from '../hooks/useGoogleFont';
 import { useAccount, useNetwork } from 'wagmi';
 import { SIWEContext } from './Standard/SIWE/SIWEContext';
-import { getGlobalChains } from '../defaultClient';
+import { useChains } from '../hooks/useChains';
 
 export const routes = {
   ONBOARDING: 'onboarding',
@@ -102,6 +102,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
       'Multiple, nested usages of ConnectKitProvider detected. Please use only one.'
     );
   }
+  const chains = useChains();
 
   // Default config options
   const defaultOptions: ConnectKitOptions = {
@@ -118,7 +119,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     disclaimer: null,
     bufferPolyfill: true,
     customAvatar: undefined,
-    initialChainId: getGlobalChains()?.[0]?.id,
+    initialChainId: chains?.[0]?.id,
     ethereumOnboardingUrl: undefined,
     walletOnboardingUrl: undefined,
   };

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -22,6 +22,7 @@ import { useThemeFont } from '../hooks/useGoogleFont';
 import { useAccount, useNetwork } from 'wagmi';
 import { SIWEContext } from './Standard/SIWE/SIWEContext';
 import { useChains } from '../hooks/useChains';
+import { useWalletConnectUri } from '../hooks/useWalletConnectUri';
 
 export const routes = {
   ONBOARDING: 'onboarding',
@@ -56,6 +57,7 @@ type ContextValue = {
   errorMessage: Error;
   options?: ConnectKitOptions;
   signInWithEthereum: boolean;
+  walletConnectUri?: string;
   debug: (message: string | React.ReactNode | null, code?: any) => void;
 };
 
@@ -166,6 +168,8 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     }
   }, [chain, route, open]);
 
+  const { uri: walletConnectUri } = useWalletConnectUri();
+
   const value = {
     theme: ckTheme,
     setTheme,
@@ -181,6 +185,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     setRoute,
     connector,
     setConnector,
+    walletConnectUri,
     signInWithEthereum: React.useContext(SIWEContext)?.enabled ?? false,
 
     // Other configuration

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -118,7 +118,7 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
     disclaimer: null,
     bufferPolyfill: true,
     customAvatar: undefined,
-    initialChainId: getGlobalChains()[0]?.id,
+    initialChainId: getGlobalChains()?.[0]?.id,
     ethereumOnboardingUrl: undefined,
     walletOnboardingUrl: undefined,
   };

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -2,10 +2,8 @@ import React, { useState } from 'react';
 import { routes, useContext } from '../ConnectKit';
 
 import supportedConnectors from '../../constants/supportedConnectors';
-import { useConnect } from '../../hooks/useConnect';
 import { useWalletConnectModal } from '../../hooks/useWalletConnectModal';
 
-import { useWalletConnectUri } from '../../hooks/useWalletConnectUri';
 import { useCoinbaseWalletUri } from '../../hooks/useCoinbaseWalletUri';
 
 import {
@@ -29,12 +27,14 @@ const ConnectWithQRCode: React.FC<{
 }> = ({ connectorId }) => {
   const context = useContext();
 
-  const { uri } =
+  const uri =
     connectorId === 'walletConnect'
-      ? useWalletConnectUri()
+      ? context.walletConnectUri
       : connectorId === 'coinbaseWallet'
-      ? useCoinbaseWalletUri()
-      : { uri: '' };
+      ? useCoinbaseWalletUri().uri
+      : '';
+
+  if (uri) console.log('uri', uri);
 
   const [id] = useState(connectorId);
   const connector = supportedConnectors.filter((c) => c.id === id)[0];

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -3,7 +3,7 @@ import { routes, useContext } from '../ConnectKit';
 
 import supportedConnectors from '../../constants/supportedConnectors';
 import { useConnect } from '../../hooks/useConnect';
-import { useDefaultWalletConnect } from '../../hooks/useDefaultWalletConnect';
+import { useWalletConnectModal } from '../../hooks/useWalletConnectModal';
 
 import { detectBrowser } from '../../utils';
 
@@ -147,12 +147,12 @@ const ConnectWithQRCode: React.FC<{
   };
 
   const [defaultModalOpen, setDefaultModalOpen] = useState(false);
-  const { openDefaultWalletConnect } = useDefaultWalletConnect();
+  const { open: openW3M } = useWalletConnectModal();
   const openDefaultConnect = async () => {
     const c = connectors.filter((c) => c.id === id)[0];
     if (c.id === 'walletConnect') {
       setDefaultModalOpen(true);
-      await openDefaultWalletConnect();
+      await openW3M();
       setDefaultModalOpen(false);
     } else {
     }

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -45,17 +45,7 @@ const ConnectWithQRCode: React.FC<{
     CONNECTORNAME: connector.name,
   });
 
-  const [defaultModalOpen, setDefaultModalOpen] = useState(false);
   const { open: openW3M, isOpen: isOpenW3M } = useWalletConnectModal();
-  const openDefaultConnect = async () => {
-    const c = connectors.filter((c) => c.id === id)[0];
-    if (c.id === 'walletConnect') {
-      setDefaultModalOpen(true);
-      await openW3M();
-      setDefaultModalOpen(false);
-    } else {
-    }
-  };
 
   if (!connector) return <>Connector not found</>;
 
@@ -124,8 +114,8 @@ const ConnectWithQRCode: React.FC<{
           {context.options?.walletConnectCTA !== 'link' && (
             <Button
               icon={<ExternalLinkIcon />}
-              onClick={openDefaultConnect}
-              waiting={defaultModalOpen}
+              onClick={openW3M}
+              waiting={isOpenW3M}
             >
               {context.options?.walletConnectCTA === 'modal'
                 ? locales.useWalletConnectModal

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { routes, useContext } from '../ConnectKit';
 
 import supportedConnectors from '../../constants/supportedConnectors';
 import { useConnect } from '../../hooks/useConnect';
 import { useWalletConnectModal } from '../../hooks/useWalletConnectModal';
 
-import { detectBrowser } from '../../utils';
+import { useWalletConnectUri } from '../../hooks/useWalletConnectUri';
+import { useCoinbaseWalletUri } from '../../hooks/useCoinbaseWalletUri';
 
 import {
   PageContent,
@@ -28,123 +29,21 @@ const ConnectWithQRCode: React.FC<{
 }> = ({ connectorId }) => {
   const context = useContext();
 
-  const [id, setId] = useState(connectorId);
+  const { uri } =
+    connectorId === 'walletConnect'
+      ? useWalletConnectUri()
+      : connectorId === 'coinbaseWallet'
+      ? useCoinbaseWalletUri()
+      : { uri: '' };
+
+  const [id] = useState(connectorId);
   const connector = supportedConnectors.filter((c) => c.id === id)[0];
 
-  const { connectors, connectAsync } = useConnect();
-  const [connectorUri, setConnectorUri] = useState<string | undefined>(
-    undefined
-  );
+  const { connectors } = useConnect();
 
   const locales = useLocales({
     CONNECTORNAME: connector.name,
   });
-
-  async function connectWallet(connector: any) {
-    const result = await connectAsync({ connector: connector });
-
-    if (result) {
-      return result;
-    }
-
-    return false;
-  }
-
-  async function connectWalletConnect(connector: any) {
-    if (connector.options?.version === '1') {
-      connector.on('message', async (e) => {
-        //@ts-ignore
-        const p = await connector.getProvider();
-        setConnectorUri(p.connector.uri);
-
-        // User rejected, regenerate QR code
-        p.connector.on('disconnect', () => {
-          connectWallet(connector);
-        });
-      });
-      try {
-        await connectWallet(connector);
-      } catch (err) {
-        context.debug(
-          <>WalletConnect cannot connect. See console for more details.</>,
-          err
-        );
-      }
-    } else {
-      connector.on('message', async (e) => {
-        const p = await connector.getProvider();
-        setConnectorUri(p.uri);
-        console.log(p.uri);
-
-        // User rejected, regenerate QR code
-        connector.on('disconnect', () => {
-          console.log('disconnect');
-        });
-        connector.on('error', () => {
-          console.log('disconnect');
-        });
-      });
-
-      try {
-        await connectWallet(connector);
-      } catch (error: any) {
-        if (error.code) {
-          switch (error.code) {
-            case 4001:
-              console.error('User rejected');
-              connectWalletConnect(connector); // Regenerate QR code
-              break;
-            default:
-              console.error('Unknown error');
-              break;
-          }
-        } else {
-          // Sometimes the error doesn't respond with a code
-          context.debug(
-            <>WalletConnect cannot connect. See console for more details.</>,
-            error
-          );
-        }
-      }
-    }
-  }
-
-  const startConnect = async () => {
-    const c = connectors.filter((c) => c.id === id)[0];
-    if (!c || connectorUri) return;
-
-    switch (c.id) {
-      case 'coinbaseWallet':
-        c.on('message', async (e) => {
-          const p = await c.getProvider();
-          setConnectorUri(p.qrUrl);
-        });
-        try {
-          await connectWallet(c);
-        } catch (err) {
-          context.debug(
-            <>
-              This dApp is most likely missing the{' '}
-              <code>headlessMode: true</code> flag in the custom{' '}
-              <code>CoinbaseWalletConnector</code> options. See{' '}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://connect.family.co/v0/docs/cbwHeadlessMode"
-              >
-                documentation
-              </a>{' '}
-              for more details.
-            </>,
-            err
-          );
-        }
-        break;
-      case 'walletConnect':
-        connectWalletConnect(c);
-        break;
-    }
-  };
 
   const [defaultModalOpen, setDefaultModalOpen] = useState(false);
   const { open: openW3M } = useWalletConnectModal();
@@ -158,32 +57,10 @@ const ConnectWithQRCode: React.FC<{
     }
   };
 
-  useEffect(() => {
-    if (!connectorUri) startConnect();
-  }, []);
-
   if (!connector) return <>Connector not found</>;
-
-  const browser = detectBrowser();
-  const extensionUrl = connector.extensions
-    ? connector.extensions[browser]
-    : undefined;
 
   const hasApps =
     connector.appUrls && Object.keys(connector.appUrls).length !== 0;
-
-  const suggestedExtension = connector.extensions
-    ? {
-        name: Object.keys(connector.extensions)[0],
-        label:
-          Object.keys(connector.extensions)[0].charAt(0).toUpperCase() +
-          Object.keys(connector.extensions)[0].slice(1), // Capitalise first letter, but this might be better suited as a lookup table
-        url: connector.extensions[Object.keys(connector.extensions)[0]],
-      }
-    : undefined;
-
-  const hasExtensionInstalled =
-    connector.extensionIsInstalled && connector.extensionIsInstalled();
 
   if (!connector.scannable)
     return (
@@ -204,7 +81,7 @@ const ConnectWithQRCode: React.FC<{
     <PageContent>
       <ModalContent style={{ paddingBottom: 8, gap: 14 }}>
         <CustomQRCode
-          value={connectorUri}
+          value={uri}
           image={connector.logos.qrCode}
           imageBackground={connector.logoBackground}
           tooltipMessage={
@@ -238,7 +115,7 @@ const ConnectWithQRCode: React.FC<{
           }}
         >
           {context.options?.walletConnectCTA !== 'modal' && (
-            <CopyToClipboard variant="button" string={connectorUri}>
+            <CopyToClipboard variant="button" string={uri}>
               {context.options?.walletConnectCTA === 'link'
                 ? locales.copyToClipboard
                 : locales.copyCode}
@@ -257,55 +134,18 @@ const ConnectWithQRCode: React.FC<{
           )}
         </div>
       )}
-
-      {/*
-      {hasExtensionInstalled && ( // Run the extension
-        <Button
-          icon={connector.logos.default}
-          roundedIcon
-          onClick={() => switchConnectMethod(id)}
-        >
-          Open {connector.name}
-        </Button>
-      )}
-
-      {!hasExtensionInstalled && extensionUrl && (
-        <Button href={extensionUrl} icon={<BrowserIcon />}>
-          {locales.installTheExtension}
-        </Button>
-      )}
-      */}
-
       {hasApps && (
         <>
           <Button
             onClick={() => {
               context.setRoute(routes.DOWNLOAD);
             }}
-            /*
-            icon={
-              <div style={{ background: connector.logoBackground }}>
-                {connector.logos.default}
-              </div>
-            }
-            roundedIcon
-            */
             download
           >
             {locales.getWalletName}
           </Button>
         </>
       )}
-      {/*
-        {suggestedExtension && (
-          <Button
-            href={suggestedExtension?.url}
-            icon={<BrowserIcon browser={suggestedExtension?.name} />}
-          >
-            Install on {suggestedExtension?.label}
-          </Button>
-        }
-        */}
     </PageContent>
   );
 };

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -113,7 +113,7 @@ const ConnectWithQRCode: React.FC<{
             <Button
               icon={<ExternalLinkIcon />}
               onClick={openW3M}
-              waiting={isOpenW3M}
+              disabled={isOpenW3M}
             >
               {context.options?.walletConnectCTA === 'modal'
                 ? locales.useWalletConnectModal

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -39,8 +39,6 @@ const ConnectWithQRCode: React.FC<{
   const [id] = useState(connectorId);
   const connector = supportedConnectors.filter((c) => c.id === id)[0];
 
-  const { connectors } = useConnect();
-
   const locales = useLocales({
     CONNECTORNAME: connector.name,
   });

--- a/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/ConnectModal/ConnectWithQRCode.tsx
@@ -46,7 +46,7 @@ const ConnectWithQRCode: React.FC<{
   });
 
   const [defaultModalOpen, setDefaultModalOpen] = useState(false);
-  const { open: openW3M } = useWalletConnectModal();
+  const { open: openW3M, isOpen: isOpenW3M } = useWalletConnectModal();
   const openDefaultConnect = async () => {
     const c = connectors.filter((c) => c.id === id)[0];
     if (c.id === 'walletConnect') {

--- a/packages/connectkit/src/components/Pages/Connectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/Connectors/index.tsx
@@ -38,7 +38,6 @@ import { useWalletConnectConnector } from '../../../hooks/connectors/useWalletCo
 //import { useMetaMaskConnector } from '../../../hooks/connectors/useMetaMaskConnector';
 import { useCoinbaseWalletConnector } from '../../../hooks/connectors/useCoinbaseWalletConnector';
 import { useInjectedConnector } from '../../../hooks/connectors/useInjectedConnector';
-import { useWalletConnectUri } from '../../../hooks/useWalletConnectUri';
 import { metaMask } from '../../../wallets/connectors/metaMask';
 import { useConnectors } from '../../../hooks/useConnectors';
 import { useConnect } from '../../../hooks/useConnect';
@@ -49,7 +48,8 @@ const Wallets: React.FC = () => {
   const locales = useLocales({});
   const mobile = isMobile();
 
-  const { uri } = useWalletConnectUri();
+  const uri = context.walletConnectUri;
+
   //const { connector: mmConnector } = useMetaMaskConnector();
   const { connector: wcConnector } = useWalletConnectConnector({});
   const { connector: cbwConnector } = useCoinbaseWalletConnector();

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -13,7 +13,7 @@ import { useConnect } from '../../../hooks/useConnect';
 import useDefaultWallets from '../../../wallets/useDefaultWallets';
 import { routes, useContext } from '../../ConnectKit';
 import { WalletProps } from '../../../wallets/wallet';
-import { useDefaultWalletConnect } from '../../../hooks/useDefaultWalletConnect';
+import { useWalletConnectModal } from '../../../hooks/useWalletConnectModal';
 import CopyToClipboard from '../../Common/CopyToClipboard';
 import { walletConnect } from '../../../wallets/connectors/walletConnect';
 import useLocales from '../../../hooks/useLocales';
@@ -43,7 +43,7 @@ const MobileConnectors: React.FC = () => {
 
   const chains = useChains();
 
-  const { openDefaultWalletConnect } = useDefaultWalletConnect();
+  const { open: openW3M } = useWalletConnectModal();
   const wallets = useDefaultWallets().filter(
     (wallet: WalletProps) => wallet.installed === undefined // Do not show wallets that are injected connectors
   );
@@ -133,7 +133,7 @@ const MobileConnectors: React.FC = () => {
                 </WalletItem>
               );
             })}
-            <WalletItem onClick={openDefaultWalletConnect}>
+            <WalletItem onClick={openW3M}>
               <WalletIcon
                 style={{ background: 'var(--ck-body-background-secondary)' }}
               >

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -44,13 +44,7 @@ const MobileConnectors: React.FC = () => {
 
   const locales = useLocales();
 
-  const [defaultModalOpen, setDefaultModalOpen] = useState(false);
-  const { open: openW3M } = useWalletConnectModal();
-  const openDefaultConnect = async () => {
-    setDefaultModalOpen(true);
-    await openW3M();
-    setDefaultModalOpen(false);
-  };
+  const { open: openW3M, isOpen: isOpenW3M } = useWalletConnectModal();
 
   const wallets = useDefaultWallets().filter(
     (wallet: WalletProps) => wallet.installed === undefined // Do not show wallets that are injected connectors
@@ -95,10 +89,7 @@ const MobileConnectors: React.FC = () => {
                 </WalletItem>
               );
             })}
-            <WalletItem
-              onClick={openDefaultConnect}
-              $waiting={defaultModalOpen}
-            >
+            <WalletItem onClick={openW3M} $waiting={isOpenW3M}>
               <WalletIcon
                 style={{ background: 'var(--ck-body-background-secondary)' }}
               >

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
   Container,
   WalletList,
@@ -9,15 +9,12 @@ import {
 
 import { PageContent, ModalContent } from '../../Common/Modal/styles';
 
-import { useConnect } from '../../../hooks/useConnect';
 import useDefaultWallets from '../../../wallets/useDefaultWallets';
 import { routes, useContext } from '../../ConnectKit';
 import { WalletProps } from '../../../wallets/wallet';
 import { useWalletConnectModal } from '../../../hooks/useWalletConnectModal';
 import CopyToClipboard from '../../Common/CopyToClipboard';
-import { walletConnect } from '../../../wallets/connectors/walletConnect';
 import useLocales from '../../../hooks/useLocales';
-import { useChains } from '../../../hooks/useChains';
 import { useWalletConnectUri } from '../../../hooks/useWalletConnectUri';
 
 const MoreIcon = (
@@ -38,7 +35,6 @@ const MoreIcon = (
 );
 const MobileConnectors: React.FC = () => {
   const context = useContext();
-  const { connectAsync } = useConnect();
 
   const { uri } = useWalletConnectUri();
 
@@ -71,7 +67,28 @@ const MobileConnectors: React.FC = () => {
                 <WalletItem
                   key={i}
                   onClick={() => connectWallet(wallet)}
-                  $waiting={!uri}
+                  initial={{
+                    opacity: 0.2,
+                  }}
+                  animate={
+                    uri
+                      ? {
+                          opacity: 1,
+                          transition: {
+                            duration: 0.1,
+                            ease: 'easeOut',
+                          },
+                        }
+                      : {
+                          opacity: [0.1, 0.8, 0.1],
+                          transition: {
+                            repeat: Infinity,
+                            duration: 1,
+                            ease: 'easeInOut',
+                            delay: i * 0.02,
+                          },
+                        }
+                  }
                 >
                   <WalletIcon
                     $outline={true}

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -17,7 +17,7 @@ import { useDefaultWalletConnect } from '../../../hooks/useDefaultWalletConnect'
 import CopyToClipboard from '../../Common/CopyToClipboard';
 import { walletConnect } from '../../../wallets/connectors/walletConnect';
 import useLocales from '../../../hooks/useLocales';
-import { getGlobalChains } from '../../../defaultClient';
+import { useChains } from '../../../hooks/useChains';
 
 const MoreIcon = (
   <svg
@@ -41,7 +41,7 @@ const MobileConnectors: React.FC = () => {
 
   const locales = useLocales();
 
-  const chains = getGlobalChains();
+  const chains = useChains();
 
   const { openDefaultWalletConnect } = useDefaultWalletConnect();
   const wallets = useDefaultWallets().filter(

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -15,7 +15,6 @@ import { WalletProps } from '../../../wallets/wallet';
 import { useWalletConnectModal } from '../../../hooks/useWalletConnectModal';
 import CopyToClipboard from '../../Common/CopyToClipboard';
 import useLocales from '../../../hooks/useLocales';
-import { useWalletConnectUri } from '../../../hooks/useWalletConnectUri';
 
 const MoreIcon = (
   <svg
@@ -36,7 +35,7 @@ const MoreIcon = (
 const MobileConnectors: React.FC = () => {
   const context = useContext();
 
-  const { uri } = useWalletConnectUri();
+  const uri = context.walletConnectUri;
 
   const locales = useLocales();
 

--- a/packages/connectkit/src/components/Pages/MobileConnectors/styles.ts
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/styles.ts
@@ -1,4 +1,5 @@
 import styled from './../../../styles/styled';
+import { motion } from 'framer-motion';
 
 export const WalletList = styled.div`
   display: grid;
@@ -7,9 +8,9 @@ export const WalletList = styled.div`
   margin: 0 -10px -20px;
   padding: 4px 0 0;
 `;
-export const WalletItem = styled.div<{ $waiting?: boolean }>`
+export const WalletItem = styled(motion.div)<{ $waiting?: boolean }>`
   text-align: center;
-  transition: opacity 100ms ease;
+  transition: opacity 300ms ease;
   opacity: ${(props) => (props.$waiting ? 0.4 : 1)};
 `;
 export const WalletIcon = styled.div<{ $outline?: boolean }>`

--- a/packages/connectkit/src/components/Pages/MobileConnectors/styles.ts
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/styles.ts
@@ -7,8 +7,10 @@ export const WalletList = styled.div`
   margin: 0 -10px -20px;
   padding: 4px 0 0;
 `;
-export const WalletItem = styled.div`
+export const WalletItem = styled.div<{ $waiting?: boolean }>`
   text-align: center;
+  transition: opacity 100ms ease;
+  opacity: ${(props) => (props.$waiting ? 0.4 : 1)};
 `;
 export const WalletIcon = styled.div<{ $outline?: boolean }>`
   z-index: 9;

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -12,7 +12,7 @@ import { infuraProvider } from 'wagmi/providers/infura';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 import { publicProvider } from 'wagmi/providers/public';
 
-let globalChains: Chain[];
+let globalChains: Chain[] = [];
 let globalAppName: string;
 let globalAppIcon: string;
 

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -65,8 +65,6 @@ const getDefaultConnectors = ({
   appName,
   walletConnectOptions,
 }: DefaultConnectorsProps) => {
-  const wcOpts: WalletConnectOptionsProps = { version: '1' };
-  /*
   const wcOpts: WalletConnectOptionsProps =
     walletConnectOptions?.version === '2' && walletConnectOptions?.projectId
       ? {
@@ -76,7 +74,6 @@ const getDefaultConnectors = ({
       : {
           version: '1',
         };
-   */
 
   return [
     new MetaMaskConnector({

--- a/packages/connectkit/src/defaultClient.ts
+++ b/packages/connectkit/src/defaultClient.ts
@@ -12,13 +12,11 @@ import { infuraProvider } from 'wagmi/providers/infura';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 import { publicProvider } from 'wagmi/providers/public';
 
-let globalChains: Chain[] = [];
 let globalAppName: string;
 let globalAppIcon: string;
 
 export const getAppName = () => globalAppName;
 export const getAppIcon = () => globalAppIcon;
-export const getGlobalChains = () => globalChains;
 
 const defaultChains = [mainnet, polygon, optimism, arbitrum];
 
@@ -152,8 +150,6 @@ const defaultClient = ({
     chains: configuredChains,
     webSocketProvider: configuredWebSocketProvider,
   } = configureChains(chains, providers);
-
-  globalChains = configuredChains;
 
   const connectKitClient: ConnectKitClientProps = {
     autoConnect,

--- a/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
@@ -1,0 +1,13 @@
+import { useConnectors } from './../useConnectors';
+
+export const useCoinbaseWalletConnector = () => {
+  const connectors = useConnectors();
+
+  const connector = connectors.find((c) => c.id === 'coinbaseWallet');
+  if (!connector) return null;
+
+  // Opinionated decisions
+  connector.options.headlessMode = true; // avoid default modal
+
+  return connector;
+};

--- a/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
@@ -1,13 +1,28 @@
-import { useConnectors } from './../useConnectors';
+import { useEffect, useState } from 'react';
+import { Connector, useConnectors } from './../useConnectors';
+
+import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet';
 
 export const useCoinbaseWalletConnector = () => {
+  const [connector, setConnector] = useState<Connector | undefined>(undefined);
+
   const connectors = useConnectors();
+  const coinbaseWallet = connectors.find((c) => c.id === 'coinbaseWallet');
 
-  const connector = connectors.find((c) => c.id === 'coinbaseWallet');
-  if (!connector) return null;
+  useEffect(() => {
+    if (coinbaseWallet) {
+      const config = {
+        ...coinbaseWallet,
+        options: {
+          ...coinbaseWallet.options,
+          headlessMode: true, // avoid default modal
+        },
+      };
+      setConnector(new CoinbaseWalletConnector(config));
+    }
+  }, []);
 
-  // Opinionated decisions
-  connector.options.headlessMode = true; // avoid default modal
-
-  return connector;
+  return {
+    connector,
+  };
 };

--- a/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useCoinbaseWalletConnector.ts
@@ -1,26 +1,15 @@
 import { useEffect, useState } from 'react';
 import { Connector, useConnectors } from './../useConnectors';
 
-import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet';
-
+// CoinbaseWalletConnector requires using the connector directly from wagmi's useConnect Hook (useConnectors) or else it won't connect properly.
 export const useCoinbaseWalletConnector = () => {
   const [connector, setConnector] = useState<Connector | undefined>(undefined);
-
   const connectors = useConnectors();
-  const coinbaseWallet = connectors.find((c) => c.id === 'coinbaseWallet');
 
   useEffect(() => {
-    if (coinbaseWallet) {
-      const config = {
-        ...coinbaseWallet,
-        options: {
-          ...coinbaseWallet.options,
-          headlessMode: true, // avoid default modal
-        },
-      };
-      setConnector(new CoinbaseWalletConnector(config));
-    }
-  }, []);
+    const coinbaseWallet = connectors.find((c) => c.id === 'coinbaseWallet');
+    if (coinbaseWallet) setConnector(coinbaseWallet);
+  }, [connectors]);
 
   return {
     connector,

--- a/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
@@ -1,19 +1,36 @@
-import { useConnectors } from './../useConnectors';
+import { useEffect, useState } from 'react';
+import { Connector, useConnectors } from './../useConnectors';
+
+import { InjectedConnector } from 'wagmi/connectors/injected';
 
 export const useInjectedConnector = () => {
+  const [connector, setConnector] = useState<Connector | undefined>(undefined);
+
   const connectors = useConnectors();
+  const injected = connectors.find((c) => c.id === 'injected');
 
-  const connector = connectors.find((c) => c.id === 'injected');
-  if (!connector) return null;
+  useEffect(() => {
+    if (injected) {
+      const config = {
+        ...injected,
+        options: {
+          ...injected.options,
+          shimDisconnect: true,
+          name: (
+            detectedName: string | string[] // Detects the name of the injected wallet
+          ) =>
+            `Injected (${
+              typeof detectedName === 'string'
+                ? detectedName
+                : detectedName.join(', ')
+            })`,
+        },
+      };
+      setConnector(new InjectedConnector(config));
+    }
+  }, []);
 
-  // Opinionated decisions
-  connector.options.shimDisconnect = true;
-  connector.options.name = (
-    detectedName: string | string[] // Detects the name of the injected wallet
-  ) =>
-    `Injected (${
-      typeof detectedName === 'string' ? detectedName : detectedName.join(', ')
-    })`;
-
-  return connector;
+  return {
+    connector,
+  };
 };

--- a/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
@@ -5,11 +5,10 @@ import { InjectedConnector } from 'wagmi/connectors/injected';
 
 export const useInjectedConnector = () => {
   const [connector, setConnector] = useState<Connector | undefined>(undefined);
-
   const connectors = useConnectors();
-  const injected = connectors.find((c) => c.id === 'injected');
 
   useEffect(() => {
+    const injected = connectors.find((c) => c.id === 'injected');
     if (injected) {
       const config = {
         ...injected,
@@ -28,7 +27,7 @@ export const useInjectedConnector = () => {
       };
       setConnector(new InjectedConnector(config));
     }
-  }, []);
+  }, [connectors]);
 
   return {
     connector,

--- a/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useInjectedConnector.ts
@@ -1,0 +1,19 @@
+import { useConnectors } from './../useConnectors';
+
+export const useInjectedConnector = () => {
+  const connectors = useConnectors();
+
+  const connector = connectors.find((c) => c.id === 'injected');
+  if (!connector) return null;
+
+  // Opinionated decisions
+  connector.options.shimDisconnect = true;
+  connector.options.name = (
+    detectedName: string | string[] // Detects the name of the injected wallet
+  ) =>
+    `Injected (${
+      typeof detectedName === 'string' ? detectedName : detectedName.join(', ')
+    })`;
+
+  return connector;
+};

--- a/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
@@ -1,0 +1,15 @@
+import { useConnectors } from './../useConnectors';
+
+export const useMetaMaskConnector = () => {
+  const connectors = useConnectors();
+
+  const connector = connectors.find((c) => c.id === 'metaMask');
+  if (!connector) return null;
+
+  // Opinionated decisions
+  connector.options.shimDisconnect = true;
+  connector.options.shimChainChangedDisconnect = false;
+  connector.options.UNSTABLE_shimOnConnectSelectAccount = true;
+
+  return connector;
+};

--- a/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
@@ -1,15 +1,30 @@
-import { useConnectors } from './../useConnectors';
+import { useEffect, useState } from 'react';
+import { Connector, useConnectors } from './../useConnectors';
+
+import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
 
 export const useMetaMaskConnector = () => {
+  const [connector, setConnector] = useState<Connector | undefined>(undefined);
+
   const connectors = useConnectors();
+  const metaMask = connectors.find((c) => c.id === 'metaMask');
 
-  const connector = connectors.find((c) => c.id === 'metaMask');
-  if (!connector) return null;
+  useEffect(() => {
+    if (metaMask) {
+      const config = {
+        ...metaMask,
+        options: {
+          ...metaMask.options,
+          shimDisconnect: true,
+          shimChainChangedDisconnect: false,
+          UNSTABLE_shimOnConnectSelectAccount: true,
+        },
+      };
+      setConnector(new MetaMaskConnector(config));
+    }
+  }, []);
 
-  // Opinionated decisions
-  connector.options.shimDisconnect = true;
-  connector.options.shimChainChangedDisconnect = false;
-  connector.options.UNSTABLE_shimOnConnectSelectAccount = true;
-
-  return connector;
+  return {
+    connector,
+  };
 };

--- a/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useMetaMaskConnector.ts
@@ -5,11 +5,10 @@ import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
 
 export const useMetaMaskConnector = () => {
   const [connector, setConnector] = useState<Connector | undefined>(undefined);
-
   const connectors = useConnectors();
-  const metaMask = connectors.find((c) => c.id === 'metaMask');
 
   useEffect(() => {
+    const metaMask = connectors.find((c) => c.id === 'metaMask');
     if (metaMask) {
       const config = {
         ...metaMask,
@@ -22,7 +21,7 @@ export const useMetaMaskConnector = () => {
       };
       setConnector(new MetaMaskConnector(config));
     }
-  }, []);
+  }, [connectors]);
 
   return {
     connector,

--- a/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
 import { Connector, useConnectors } from './../useConnectors';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 
 export const useWalletConnectConnector = ({
   qrcode = false, // avoids default modal
@@ -8,22 +8,13 @@ export const useWalletConnectConnector = ({
   qrcode?: boolean;
 }) => {
   const [connector, setConnector] = useState<Connector | undefined>(undefined);
-
   const connectors = useConnectors();
-  const walletConnect = connectors.find((c) => c.id === 'walletConnect');
+  const { isConnected } = useAccount();
 
   useEffect(() => {
-    if (walletConnect) {
-      const config = {
-        ...walletConnect,
-        options: {
-          ...walletConnect.options,
-          qrcode,
-        },
-      };
-      setConnector(new WalletConnectConnector(config));
-    }
-  }, []);
+    const walletConnect = connectors.find((c) => c.id === 'walletConnect');
+    if (walletConnect) setConnector(walletConnect);
+  }, [connectors, isConnected]);
 
   return {
     connector,

--- a/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
@@ -1,13 +1,31 @@
-import { useConnectors } from './../useConnectors';
+import { useEffect, useState } from 'react';
+import { Connector, useConnectors } from './../useConnectors';
+import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 
-export const useWalletConnectConnector = () => {
+export const useWalletConnectConnector = ({
+  qrcode = false, // avoids default modal
+}: {
+  qrcode?: boolean;
+}) => {
+  const [connector, setConnector] = useState<Connector | undefined>(undefined);
+
   const connectors = useConnectors();
+  const walletConnect = connectors.find((c) => c.id === 'walletConnect');
 
-  const connector = connectors.find((c) => c.id === 'walletConnect');
-  if (!connector) return null;
+  useEffect(() => {
+    if (walletConnect) {
+      const config = {
+        ...walletConnect,
+        options: {
+          ...walletConnect.options,
+          qrcode,
+        },
+      };
+      setConnector(new WalletConnectConnector(config));
+    }
+  }, []);
 
-  // Opinionated decisions
-  connector.options.qrCode = false; // avoid default modal
-
-  return connector;
+  return {
+    connector,
+  };
 };

--- a/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
+++ b/packages/connectkit/src/hooks/connectors/useWalletConnectConnector.ts
@@ -1,0 +1,13 @@
+import { useConnectors } from './../useConnectors';
+
+export const useWalletConnectConnector = () => {
+  const connectors = useConnectors();
+
+  const connector = connectors.find((c) => c.id === 'walletConnect');
+  if (!connector) return null;
+
+  // Opinionated decisions
+  connector.options.qrCode = false; // avoid default modal
+
+  return connector;
+};

--- a/packages/connectkit/src/hooks/useChains.ts
+++ b/packages/connectkit/src/hooks/useChains.ts
@@ -1,0 +1,7 @@
+import { useConnect } from 'wagmi';
+
+export function useChains() {
+  // TODO: Find a better way to get configuration chains, but for now just grab first connector's chains
+  const { connectors } = useConnect();
+  return connectors[0]?.chains;
+}

--- a/packages/connectkit/src/hooks/useChains.ts
+++ b/packages/connectkit/src/hooks/useChains.ts
@@ -1,7 +1,7 @@
-import { useConnect } from 'wagmi';
+import { useConnectors } from './useConnectors';
 
 export function useChains() {
   // TODO: Find a better way to get configuration chains, but for now just grab first connector's chains
-  const { connectors } = useConnect();
+  const connectors = useConnectors();
   return connectors[0]?.chains;
 }

--- a/packages/connectkit/src/hooks/useCoinbaseWalletUri.tsx
+++ b/packages/connectkit/src/hooks/useCoinbaseWalletUri.tsx
@@ -13,7 +13,24 @@ export function useCoinbaseWalletUri() {
   const { connectAsync } = useConnect();
 
   useEffect(() => {
-    if (connector) connectCoinbaseWallet(connector);
+    async function handleMessage(e: any) {
+      console.log('CBW Message', e);
+      if (connector) {
+        if (e.type === 'connecting') {
+          const p = await connector.getProvider();
+          setUri(p.qrUrl);
+        }
+      }
+    }
+    if (connector) {
+      console.log('add cbw listeners');
+      connectCoinbaseWallet(connector);
+      connector.on('message', handleMessage);
+      return () => {
+        console.log('remove cbw listeners');
+        connector.off('message', handleMessage);
+      };
+    }
   }, [connector]);
 
   async function connectWallet(connector: any) {
@@ -23,10 +40,6 @@ export function useCoinbaseWalletUri() {
   }
 
   async function connectCoinbaseWallet(connector: any) {
-    connector.on('message', async (e) => {
-      const p = await connector.getProvider();
-      setUri(p.qrUrl);
-    });
     try {
       await connectWallet(connector);
     } catch (err) {

--- a/packages/connectkit/src/hooks/useCoinbaseWalletUri.tsx
+++ b/packages/connectkit/src/hooks/useCoinbaseWalletUri.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+
+import { useConnect } from './useConnect';
+import { useCoinbaseWalletConnector } from './connectors/useCoinbaseWalletConnector';
+import { useContext } from '../components/ConnectKit';
+
+export function useCoinbaseWalletUri() {
+  const [uri, setUri] = useState<string | undefined>(undefined);
+
+  const context = useContext();
+
+  const { connector } = useCoinbaseWalletConnector();
+  const { connectAsync } = useConnect();
+
+  useEffect(() => {
+    if (connector) connectCoinbaseWallet(connector);
+  }, [connector]);
+
+  async function connectWallet(connector: any) {
+    const result = await connectAsync({ connector });
+    if (result) return result;
+    return false;
+  }
+
+  async function connectCoinbaseWallet(connector: any) {
+    connector.on('message', async (e) => {
+      const p = await connector.getProvider();
+      setUri(p.qrUrl);
+    });
+    try {
+      await connectWallet(connector);
+    } catch (err) {
+      context.debug(
+        <>
+          This dApp is most likely missing the <code>headlessMode: true</code>{' '}
+          flag in the custom <code>CoinbaseWalletConnector</code> options. See{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://connect.family.co/v0/docs/cbwHeadlessMode"
+          >
+            documentation
+          </a>{' '}
+          for more details.
+        </>,
+        err
+      );
+    }
+  }
+
+  return {
+    uri,
+  };
+}

--- a/packages/connectkit/src/hooks/useConnect.tsx
+++ b/packages/connectkit/src/hooks/useConnect.tsx
@@ -4,19 +4,25 @@ import { useContext } from '../components/ConnectKit';
 export function useConnect() {
   const context = useContext();
 
-  const { connectAsync, connectors } = wagmiUseConnect({
+  const { connect, connectAsync, connectors, ...rest } = wagmiUseConnect({
     onError(err) {
       if (err.message) {
         if (err.message !== 'User rejected request') {
-          context.debug(err.message, err);
+          console.log(err.message, err);
         }
       } else {
-        context.debug(`Could not connect. See console for more details.`, err);
+        console.log(`Could not connect.`, err);
       }
     },
   });
 
   return {
+    connect: ({ props }) => {
+      return connect({
+        ...props,
+        chainId: context.options?.initialChainId,
+      });
+    },
     connectAsync: async ({ ...props }) => {
       return await connectAsync({
         ...props,
@@ -24,5 +30,6 @@ export function useConnect() {
       });
     },
     connectors,
+    ...rest,
   };
 }

--- a/packages/connectkit/src/hooks/useConnectors.ts
+++ b/packages/connectkit/src/hooks/useConnectors.ts
@@ -1,0 +1,6 @@
+import { useConnect } from 'wagmi';
+
+export function useConnectors() {
+  const { connectors } = useConnect();
+  return connectors;
+}

--- a/packages/connectkit/src/hooks/useConnectors.ts
+++ b/packages/connectkit/src/hooks/useConnectors.ts
@@ -1,6 +1,8 @@
-import { useConnect } from 'wagmi';
+import { Connector, useConnect } from 'wagmi';
 
 export function useConnectors() {
   const { connectors } = useConnect();
   return connectors;
 }
+
+export { Connector };

--- a/packages/connectkit/src/hooks/useDefaultWalletConnect.tsx
+++ b/packages/connectkit/src/hooks/useDefaultWalletConnect.tsx
@@ -7,6 +7,11 @@ export function useDefaultWalletConnect() {
   const { connectAsync, connectors } = useConnect();
   return {
     openDefaultWalletConnect: async () => {
+      //add modal styling because wagmi does not let you add styling to the modal
+      const w3mcss = document.createElement('style');
+      w3mcss.innerHTML = `w3m-modal{ --w3m-modal-z-index:2147483647; }`;
+      document.head.appendChild(w3mcss);
+
       const c: Connector<any, any> | undefined = connectors.find(
         (c) => c.id === 'walletConnect'
       );
@@ -21,6 +26,9 @@ export function useDefaultWalletConnect() {
         } catch (err) {
           console.log('WalletConnect', err);
         }
+
+        // remove modal styling
+        document.head.removeChild(w3mcss);
       } else {
         console.log('No WalletConnect connector available');
       }

--- a/packages/connectkit/src/hooks/useIsMobile.tsx
+++ b/packages/connectkit/src/hooks/useIsMobile.tsx
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { isMobile } from '../utils';
+
+export default function useIsMobile() {
+  const [mobile, setMobile] = useState(false);
+  useEffect(() => {
+    function handleResize() {
+      setMobile(isMobile());
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return mobile;
+}

--- a/packages/connectkit/src/hooks/useLocales.tsx
+++ b/packages/connectkit/src/hooks/useLocales.tsx
@@ -70,7 +70,7 @@ const wrapTags = (text: string) => {
       return r.split(/(\[WALLETCONNECTLOGO\])/g).map((s) => {
         if (s === '[WALLETCONNECTLOGO]') {
           return (
-            <span className="ck-tt-logo">
+            <span key={s} className="ck-tt-logo">
               <Logos.WalletConnect />
             </span>
           );

--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -1,10 +1,12 @@
-import { Connector } from 'wagmi';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
-
 import { useConnect } from './useConnect';
+import { useWalletConnectConnector } from './connectors/useWalletConnectConnector';
 
 export function useWalletConnectModal() {
-  const { connectAsync, connectors } = useConnect();
+  const { connectAsync } = useConnect();
+  const { connector } = useWalletConnectConnector({
+    qrcode: true,
+  });
+
   return {
     open: async () => {
       //add modal styling because wagmi does not let you add styling to the modal
@@ -12,17 +14,9 @@ export function useWalletConnectModal() {
       w3mcss.innerHTML = `w3m-modal{ --w3m-modal-z-index:2147483647; }`;
       document.head.appendChild(w3mcss);
 
-      const c: Connector<any, any> | undefined = connectors.find(
-        (c) => c.id === 'walletConnect'
-      );
-      if (c) {
-        const connector = new WalletConnectConnector({
-          chains: c.chains,
-          options: { ...c.options, qrcode: true },
-        });
-
+      if (connector) {
         try {
-          await connectAsync({ connector: connector });
+          await connectAsync({ connector });
         } catch (err) {
           console.log('WalletConnect', err);
         }

--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -1,13 +1,16 @@
 import { useConnect } from './useConnect';
 import { useWalletConnectConnector } from './connectors/useWalletConnectConnector';
+import { useState } from 'react';
 
 export function useWalletConnectModal() {
   const { connectAsync } = useConnect();
   const { connector } = useWalletConnectConnector({
     qrcode: true,
   });
+  const [isOpen, setIsOpen] = useState(false);
 
   return {
+    isOpen,
     open: async () => {
       //add modal styling because wagmi does not let you add styling to the modal
       const w3mcss = document.createElement('style');
@@ -15,11 +18,13 @@ export function useWalletConnectModal() {
       document.head.appendChild(w3mcss);
 
       if (connector) {
+        setIsOpen(true);
         try {
           await connectAsync({ connector });
         } catch (err) {
           console.log('WalletConnect', err);
         }
+        setIsOpen(false);
 
         // remove modal styling
         document.head.removeChild(w3mcss);

--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -3,10 +3,10 @@ import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 
 import { useConnect } from './useConnect';
 
-export function useDefaultWalletConnect() {
+export function useWalletConnectModal() {
   const { connectAsync, connectors } = useConnect();
   return {
-    openDefaultWalletConnect: async () => {
+    open: async () => {
       //add modal styling because wagmi does not let you add styling to the modal
       const w3mcss = document.createElement('style');
       w3mcss.innerHTML = `w3m-modal{ --w3m-modal-z-index:2147483647; }`;

--- a/packages/connectkit/src/hooks/useWalletConnectUri.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectUri.tsx
@@ -25,7 +25,6 @@ export function useWalletConnectUri() {
   async function connectWalletConnect(connector: any) {
     if (connector.options?.version === '1') {
       connector.on('message', async (e) => {
-        //@ts-ignore
         const p = await connector.getProvider();
         setUri(p.connector.uri);
 
@@ -46,7 +45,6 @@ export function useWalletConnectUri() {
       connector.on('message', async (e) => {
         const p = await connector.getProvider();
         setUri(p.uri);
-        console.log(p.uri);
 
         // User rejected, regenerate QR code
         connector.on('disconnect', () => {

--- a/packages/connectkit/src/hooks/useWalletConnectUri.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectUri.tsx
@@ -113,6 +113,10 @@ export function useWalletConnectUri() {
                   console.log('User rejected', error.code, error);
                   connectWalletConnect(connector); // Regenerate QR code
                   break;
+                case -32000:
+                  console.log('Failed to process request', error.code, error);
+                  connectWalletConnect(connector); // Regenerate QR code
+                  break;
                 default:
                   console.log(
                     'Unknown error. User will probably need to reload app...',

--- a/packages/connectkit/src/hooks/useWalletConnectUri.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectUri.tsx
@@ -1,83 +1,135 @@
 import { useState, useEffect } from 'react';
 
-import { useConnect } from './useConnect';
+import { useAccount, useConnect } from 'wagmi';
 import { useWalletConnectConnector } from './connectors/useWalletConnectConnector';
-import { useContext } from '../components/ConnectKit';
 
 export function useWalletConnectUri() {
   const [uri, setUri] = useState<string | undefined>(undefined);
 
-  const context = useContext();
-
   const { connector } = useWalletConnectConnector({});
-  const { connectAsync } = useConnect();
+  const { isConnected } = useAccount();
+  const { connectAsync } = useConnect({
+    onError: (error: any) => console.log('error', error),
+    onSuccess: (result: any) => console.log('success', result),
+    onMutate: () => console.log('mutate'),
+    onSettled: () => console.log('settled'),
+  });
 
   useEffect(() => {
-    if (connector) connectWalletConnect(connector);
-  }, [connector]);
-
-  async function connectWallet(connector: any) {
-    const result = await connectAsync({ connector });
-    if (result) return result;
-    return false;
-  }
-
-  async function connectWalletConnect(connector: any) {
-    if (connector.options?.version === '1') {
-      connector.on('message', async (e) => {
-        const p = await connector.getProvider();
-        setUri(p.connector.uri);
-
-        // User rejected, regenerate QR code
-        p.connector.on('disconnect', () => {
-          connectWallet(connector);
-        });
-      });
-      try {
-        await connectWallet(connector);
-      } catch (err) {
-        context.debug(
-          <>WalletConnect cannot connect. See console for more details.</>,
-          err
-        );
-      }
-    } else {
-      connector.on('message', async (e) => {
-        const p = await connector.getProvider();
-        setUri(p.uri);
-
-        // User rejected, regenerate QR code
-        connector.on('disconnect', () => {
-          console.log('disconnect');
-        });
-        connector.on('error', () => {
-          console.log('disconnect');
-        });
-      });
-
-      try {
-        await connectWallet(connector);
-      } catch (error: any) {
-        if (error.code) {
-          switch (error.code) {
-            case 4001:
-              console.error('User rejected');
-              connectWalletConnect(connector); // Regenerate QR code
-              break;
-            default:
-              console.error('Unknown error');
-              break;
-          }
+    async function handleMessage(e: any) {
+      console.log('WC Message', e);
+      if (connector) {
+        if (connector.options?.version === '1') {
+          // Wallet Connect v1
+          const p = await connector.getProvider();
+          setUri(p.connector.uri);
         } else {
-          // Sometimes the error doesn't respond with a code
-          context.debug(
-            <>WalletConnect cannot connect. See console for more details.</>,
-            error
-          );
+          // Wallet Connect v2
+          switch (e.type) {
+            case 'display_uri':
+              setUri(e.data);
+              break;
+            /*
+            case 'connecting':
+              const p = await connector.getProvider();
+              setUri(p.uri);
+              break;
+              */
+            default:
+              console.log('unknown message type', e.type);
+          }
         }
       }
     }
-  }
+    async function handleChange(e: any) {
+      console.log('WC Change', e);
+    }
+    async function handleDisconnect() {
+      console.log('WC Disconnect');
+
+      if (connector) {
+        if (connector.options?.version === '1') {
+          connectWallet(connector);
+        }
+      }
+    }
+    async function handleConnect() {
+      console.log('WC Connect');
+    }
+    async function handleError(e: any) {
+      console.log('WC Error', e);
+    }
+
+    if (connector && !isConnected) {
+      connectWalletConnect(connector);
+      console.log('add wc listeners');
+      connector.on('message', handleMessage);
+      connector.on('change', handleChange);
+      connector.on('connect', handleConnect);
+      connector.on('disconnect', handleDisconnect);
+      connector.on('error', handleError);
+      return () => {
+        console.log('remove wc listeners');
+        connector.off('message', handleMessage);
+        connector.off('change', handleChange);
+        connector.off('connect', handleConnect);
+        connector.off('disconnect', handleDisconnect);
+        connector.off('error', handleError);
+      };
+    }
+
+    async function connectWallet(connector: any) {
+      const result = await connectAsync({ connector });
+      if (result) return result;
+      return false;
+    }
+
+    async function connectWalletConnect(connector: any) {
+      if (!connector) console.log('no connector found to connect to');
+      if (connector.options?.version === '1') {
+        // Wallet Connect v1
+        try {
+          await connectWallet(connector);
+        } catch (err) {
+          console.log(
+            'WalletConnect cannot connect. See console for more details.',
+            err
+          );
+        }
+      } else {
+        // Wallet Connect v2
+        try {
+          console.log('try to connect', connector);
+          // Wait for user to approve
+          await connectWallet(connector);
+        } catch (error: any) {
+          console.log('cannot connect', error);
+
+          if (error) {
+            if (error.code) {
+              switch (error.code) {
+                // If user rejects regenerate URI or WalletConnect does something unexpected
+                case 4001:
+                  console.log('User rejected', error.code, error);
+                  connectWalletConnect(connector); // Regenerate QR code
+                  break;
+                default:
+                  console.log(
+                    'Unknown error. User will probably need to reload app...',
+                    error.code,
+                    error
+                  );
+                  break;
+              }
+            } else {
+              // Sometimes the error doesn't respond with a code
+              console.log('WalletConnect cannot connect.', error);
+            }
+          }
+        }
+      }
+    }
+  }, [connector, isConnected]);
 
   return {
     uri,

--- a/packages/connectkit/src/hooks/useWalletConnectUri.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectUri.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'react';
+
+import { useConnect } from './useConnect';
+import { useWalletConnectConnector } from './connectors/useWalletConnectConnector';
+import { useContext } from '../components/ConnectKit';
+
+export function useWalletConnectUri() {
+  const [uri, setUri] = useState<string | undefined>(undefined);
+
+  const context = useContext();
+
+  const { connector } = useWalletConnectConnector({});
+  const { connectAsync } = useConnect();
+
+  useEffect(() => {
+    if (connector) connectWalletConnect(connector);
+  }, [connector]);
+
+  async function connectWallet(connector: any) {
+    const result = await connectAsync({ connector });
+    if (result) return result;
+    return false;
+  }
+
+  async function connectWalletConnect(connector: any) {
+    if (connector.options?.version === '1') {
+      connector.on('message', async (e) => {
+        //@ts-ignore
+        const p = await connector.getProvider();
+        setUri(p.connector.uri);
+
+        // User rejected, regenerate QR code
+        p.connector.on('disconnect', () => {
+          connectWallet(connector);
+        });
+      });
+      try {
+        await connectWallet(connector);
+      } catch (err) {
+        context.debug(
+          <>WalletConnect cannot connect. See console for more details.</>,
+          err
+        );
+      }
+    } else {
+      connector.on('message', async (e) => {
+        const p = await connector.getProvider();
+        setUri(p.uri);
+        console.log(p.uri);
+
+        // User rejected, regenerate QR code
+        connector.on('disconnect', () => {
+          console.log('disconnect');
+        });
+        connector.on('error', () => {
+          console.log('disconnect');
+        });
+      });
+
+      try {
+        await connectWallet(connector);
+      } catch (error: any) {
+        if (error.code) {
+          switch (error.code) {
+            case 4001:
+              console.error('User rejected');
+              connectWalletConnect(connector); // Regenerate QR code
+              break;
+            default:
+              console.error('Unknown error');
+              break;
+          }
+        } else {
+          // Sometimes the error doesn't respond with a code
+          context.debug(
+            <>WalletConnect cannot connect. See console for more details.</>,
+            error
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    uri,
+  };
+}

--- a/packages/connectkit/src/hooks/useWindowSize.tsx
+++ b/packages/connectkit/src/hooks/useWindowSize.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+export default function useWindowSize() {
+  const [windowSize, setWindowSize] = useState<{
+    width: number;
+    height: number;
+  }>({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -15,6 +15,7 @@ export { default as Avatar } from './components/Common/Avatar';
 export { default as ChainIcon } from './components/Common/Chain';
 
 // Hooks
+export { default as useIsMounted } from './hooks/useIsMounted'; // Useful for apps that use SSR
 export { useChains } from './hooks/useChains';
 
 // TODO: Make this private

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -1,5 +1,5 @@
 export * as Types from './types';
-export { default as getDefaultClient, getGlobalChains } from './defaultClient';
+export { default as getDefaultClient } from './defaultClient';
 
 export { useModal } from './components/ConnectKit';
 
@@ -13,6 +13,9 @@ export { default as SIWEButton } from './components/Standard/SIWE';
 //export { default as BalanceButton, Balance } from './components/BalanceButton';
 export { default as Avatar } from './components/Common/Avatar';
 export { default as ChainIcon } from './components/Common/Chain';
+
+// Hooks
+export { useChains } from './hooks/useChains';
 
 // TODO: Make this private
 export { default as supportedConnectors } from './constants/supportedConnectors';

--- a/packages/connectkit/src/wallets/connectors/argent.tsx
+++ b/packages/connectkit/src/wallets/connectors/argent.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const argent = ({ chains }: WalletOptions): WalletProps => {
+export const argent = (): WalletProps => {
   return {
     id: 'argent',
     name: 'Argent',
@@ -23,24 +18,10 @@ export const argent = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=im.argent.contractwalletclient',
       ios: 'https://apps.apple.com/app/argent/id1358741926',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://argent.link/app/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://argent.link/app/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/brave.tsx
+++ b/packages/connectkit/src/wallets/connectors/brave.tsx
@@ -1,10 +1,8 @@
-import { WalletProps, WalletOptions } from './../wallet';
-
-import { InjectedConnector } from 'wagmi/connectors/injected';
+import { WalletProps } from './../wallet';
 
 import Logos from './../../assets/logos';
 
-export const brave = ({ chains }: WalletOptions): WalletProps => {
+export const brave = (): WalletProps => {
   const isInstalled =
     typeof window !== 'undefined' && window.ethereum?.isBraveWallet === true;
 
@@ -19,13 +17,6 @@ export const brave = ({ chains }: WalletOptions): WalletProps => {
     scannable: false,
     downloadUrls: {},
     installed: isInstalled,
-    createConnector: () => {
-      return {
-        connector: new InjectedConnector({
-          chains,
-          options: { shimDisconnect: true },
-        }),
-      };
-    },
+    createUri: (uri: string) => uri,
   };
 };

--- a/packages/connectkit/src/wallets/connectors/coinbaseWallet.tsx
+++ b/packages/connectkit/src/wallets/connectors/coinbaseWallet.tsx
@@ -1,13 +1,9 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet';
+import { WalletProps } from './../wallet';
 
 import { isMobile, isCoinbaseWallet } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const coinbaseWallet = ({
-  chains,
-  appName,
-}: WalletOptions): WalletProps => {
+export const coinbaseWallet = (): WalletProps => {
   const isInstalled = isCoinbaseWallet();
   const shouldUseWalletConnect = isMobile() && !isInstalled;
 
@@ -34,21 +30,8 @@ export const coinbaseWallet = ({
       chrome:
         'https://chrome.google.com/webstore/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad',
     },
-    createConnector: () => {
-      const connector = new CoinbaseWalletConnector({
-        chains,
-        options: {
-          appName: appName ?? '',
-          headlessMode: true,
-        },
-      });
-
-      const getUri = async () => (await connector.getProvider()).qrUrl;
-
-      return {
-        connector,
-        qrCode: { getUri },
-      };
+    createUri: (uri: string) => {
+      return `https://go.cb-w.com/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/frontier.tsx
+++ b/packages/connectkit/src/wallets/connectors/frontier.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const frontier = ({ chains }: WalletOptions): WalletProps => {
+export const frontier = (): WalletProps => {
   return {
     id: 'frontier',
     name: 'Frontier',
@@ -24,24 +19,8 @@ export const frontier = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=com.frontierwallet',
       website: 'https://frontier.xyz/',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `frontier://wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid() ? uri : `frontier://wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/gnosisSafe.tsx
+++ b/packages/connectkit/src/wallets/connectors/gnosisSafe.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const gnosisSafe = ({ chains }: WalletOptions): WalletProps => {
+export const gnosisSafe = (): WalletProps => {
   return {
     id: 'gnosisSafe',
     name: 'Gnosis Safe',
@@ -24,24 +19,10 @@ export const gnosisSafe = ({ chains }: WalletOptions): WalletProps => {
       android: 'https://play.google.com/store/apps/details?id=io.gnosis.safe',
       website: 'https://gnosis-safe.io/',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://gnosis-safe.io/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://gnosis-safe.io/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/imToken.tsx
+++ b/packages/connectkit/src/wallets/connectors/imToken.tsx
@@ -1,13 +1,8 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import Logos from './../../assets/logos';
 
-export const imToken = ({ chains }: WalletOptions): WalletProps => {
+export const imToken = (): WalletProps => {
   return {
     id: 'imToken',
     name: 'imToken',
@@ -22,21 +17,8 @@ export const imToken = ({ chains }: WalletOptions): WalletProps => {
       android: 'https://play.google.com/store/apps/details?id=im.token.app',
       ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-            return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/injected.tsx
+++ b/packages/connectkit/src/wallets/connectors/injected.tsx
@@ -1,12 +1,10 @@
-import { WalletProps, WalletOptions } from './../wallet';
-import { InjectedConnector } from 'wagmi/connectors/injected';
+import { WalletProps } from './../wallet';
 
 import { isMobile } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const injected = ({ chains }: WalletOptions): WalletProps => {
+export const injected = (): WalletProps => {
   const isInstalled = typeof window !== 'undefined' && Boolean(window.ethereum);
-
   const shouldUseWalletConnect = isMobile() && !isInstalled;
 
   return {
@@ -16,15 +14,5 @@ export const injected = ({ chains }: WalletOptions): WalletProps => {
     scannable: false,
     logos: { default: <Logos.Injected /> },
     installed: Boolean(!shouldUseWalletConnect ? isInstalled : false),
-    createConnector: () => {
-      const connector = new InjectedConnector({
-        chains,
-        options: { shimDisconnect: true },
-      });
-
-      return {
-        connector,
-      };
-    },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/ledger.tsx
+++ b/packages/connectkit/src/wallets/connectors/ledger.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const ledger = ({ chains }: WalletOptions): WalletProps => {
+export const ledger = (): WalletProps => {
   return {
     id: 'ledger',
     name: 'Ledger Live',
@@ -24,30 +19,10 @@ export const ledger = ({ chains }: WalletOptions): WalletProps => {
       android: 'https://play.google.com/store/apps/details?id=com.ledger.live',
       ios: 'https://apps.apple.com/app/ledger-live-web3-wallet/id1361671700',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        desktop: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-            return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/metaMask.tsx
+++ b/packages/connectkit/src/wallets/connectors/metaMask.tsx
@@ -1,17 +1,11 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
-import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
+import { WalletProps } from './../wallet';
 
 import { isMobile, isMetaMask, isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const metaMask = ({ chains }: WalletOptions): WalletProps => {
+export const metaMask = (): WalletProps => {
   const isInstalled = isMetaMask();
-  const shouldUseWalletConnect = isMobile() && !isInstalled;
+  const shouldUseWalletConnect = isMobile() && !isInstalled; // use walletconnect on mobile if not using metamask in-app browser
 
   return {
     id: 'metaMask',
@@ -56,49 +50,10 @@ export const metaMask = ({ chains }: WalletOptions): WalletProps => {
       edge: 'https://microsoftedge.microsoft.com/addons/detail/metamask/ejbalbakoplchlghecdalmeeeajnimhm',
     },
     installed: Boolean(!shouldUseWalletConnect ? isInstalled : false),
-    createConnector: () => {
-      const connector = shouldUseWalletConnect
-        ? getDefaultWalletConnectConnector(chains)
-        : new MetaMaskConnector({
-            chains,
-            options: {
-              shimDisconnect: true,
-              shimChainChangedDisconnect: false,
-              UNSTABLE_shimOnConnectSelectAccount: true,
-            },
-          });
-
-      return {
-        connector,
-        getUri: async () => {},
-        getMobileConnector: shouldUseWalletConnect
-          ? async () => {
-              connector.on('error', (err) => {
-                console.log('onError', err);
-              });
-              connector.on('message', async ({ type }) => {
-                console.log('onMessage: MetaMask', type);
-                if (type === 'connecting') {
-                  let uriString = '';
-                  try {
-                    const uri = await getProviderUri(connector);
-                    uriString = isAndroid()
-                      ? uri
-                      : `https://metamask.app.link/wc?uri=${encodeURIComponent(
-                          uri
-                        )}`;
-
-                    window.location.href = uriString;
-                  } catch {
-                    console.log('catch bad URI', uriString);
-                  }
-                }
-              });
-
-              return connector;
-            }
-          : undefined,
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://metamask.app.link/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/onto.tsx
+++ b/packages/connectkit/src/wallets/connectors/onto.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getProviderUri,
-  getDefaultWalletConnectConnector,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const onto = ({ chains }: WalletOptions): WalletProps => {
+export const onto = (): WalletProps => {
   return {
     id: 'onto',
     name: 'ONTO',
@@ -24,24 +19,10 @@ export const onto = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=com.github.ontio.onto',
       website: 'https://onto.app/en/download/',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://onto.app/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://onto.app/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/rainbow.tsx
+++ b/packages/connectkit/src/wallets/connectors/rainbow.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const rainbow = ({ chains }: WalletOptions): WalletProps => {
+export const rainbow = (): WalletProps => {
   return {
     id: 'rainbow',
     name: 'Rainbow',
@@ -24,24 +19,10 @@ export const rainbow = ({ chains }: WalletOptions): WalletProps => {
       android: 'https://play.google.com/store/apps/details?id=me.rainbow',
       ios: 'https://apps.apple.com/app/rainbow-ethereum-wallet/id1457119021',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://rnbwapp.com/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://rnbwapp.com/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/slope.tsx
+++ b/packages/connectkit/src/wallets/connectors/slope.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const slope = ({ chains }: WalletOptions): WalletProps => {
+export const slope = (): WalletProps => {
   return {
     id: 'slope',
     name: 'Slope',
@@ -25,24 +20,10 @@ export const slope = ({ chains }: WalletOptions): WalletProps => {
         'https://chrome.google.com/webstore/detail/slope-wallet/pocmplpaccanhmnllbbkpgfliimjljgo',
       website: 'https://slope.finance/',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://slope.finance/app/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://slope.finance/app/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/steak.tsx
+++ b/packages/connectkit/src/wallets/connectors/steak.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getProviderUri,
-  getDefaultWalletConnectConnector,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const steak = ({ chains }: WalletOptions): WalletProps => {
+export const steak = (): WalletProps => {
   return {
     id: 'steak',
     name: 'Steak',
@@ -24,26 +19,10 @@ export const steak = ({ chains }: WalletOptions): WalletProps => {
       ios: 'https://apps.apple.com/app/steakwallet/id1569375204',
       website: 'https://steakwallet.fi/download',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://links.steakwallet.fi/wc?uri=${encodeURIComponent(
-                  uri
-                )}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://links.steakwallet.fi/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/trust.tsx
+++ b/packages/connectkit/src/wallets/connectors/trust.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const trust = ({ chains }: WalletOptions): WalletProps => {
+export const trust = (): WalletProps => {
   return {
     id: 'trust',
     name: 'Trust Wallet',
@@ -24,26 +19,10 @@ export const trust = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',
       ios: 'https://apps.apple.com/app/trust-crypto-bitcoin-wallet/id1288339409',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://link.trustwallet.com/wc?uri=${encodeURIComponent(
-                  uri
-                )}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://link.trustwallet.com/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/unstoppable.tsx
+++ b/packages/connectkit/src/wallets/connectors/unstoppable.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getProviderUri,
-  getDefaultWalletConnectConnector,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const unstoppable = ({ chains }: WalletOptions): WalletProps => {
+export const unstoppable = (): WalletProps => {
   return {
     id: 'unstoppable',
     name: 'Unstoppable',
@@ -23,24 +18,10 @@ export const unstoppable = ({ chains }: WalletOptions): WalletProps => {
       android:
         'https://play.google.com/store/apps/details?id=io.horizontalsystems.bankwallet',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://unstoppable.money/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://unstoppable.money/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/connectors/walletConnect.tsx
+++ b/packages/connectkit/src/wallets/connectors/walletConnect.tsx
@@ -1,13 +1,8 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getProviderUri,
-  getDefaultWalletConnectConnector,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import Logos from './../../assets/logos';
 
-export const walletConnect = ({ chains }: WalletOptions): WalletProps => {
+export const walletConnect = (): WalletProps => {
   return {
     id: 'walletConnect',
     name: 'Other Wallets',
@@ -20,15 +15,6 @@ export const walletConnect = ({ chains }: WalletOptions): WalletProps => {
     },
     logoBackground: 'var(--ck-brand-walletConnect)',
     scannable: true,
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
-    },
+    createUri: (uri: string) => uri,
   };
 };

--- a/packages/connectkit/src/wallets/connectors/zerion.tsx
+++ b/packages/connectkit/src/wallets/connectors/zerion.tsx
@@ -1,14 +1,9 @@
-import {
-  WalletProps,
-  WalletOptions,
-  getDefaultWalletConnectConnector,
-  getProviderUri,
-} from './../wallet';
+import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
 
-export const zerion = ({ chains }: WalletOptions): WalletProps => {
+export const zerion = (): WalletProps => {
   return {
     id: 'zerion',
     name: 'Zerion',
@@ -24,24 +19,10 @@ export const zerion = ({ chains }: WalletOptions): WalletProps => {
         'https://play.google.com/store/apps/details?id=io.zerion.android',
       website: 'https://zerion.io/',
     },
-    createConnector: () => {
-      const connector = getDefaultWalletConnectConnector(chains);
-
-      return {
-        connector,
-        mobile: {
-          getUri: async () => {
-            const uri = await getProviderUri(connector);
-
-            return isAndroid()
-              ? uri
-              : `https://app.zerion.io/wc?uri=${encodeURIComponent(uri)}`;
-          },
-        },
-        qrCode: {
-          getUri: async () => await getProviderUri(connector),
-        },
-      };
+    createUri: (uri: string) => {
+      return isAndroid()
+        ? uri
+        : `https://app.zerion.io/wc?uri=${encodeURIComponent(uri)}`;
     },
   };
 };

--- a/packages/connectkit/src/wallets/index.ts
+++ b/packages/connectkit/src/wallets/index.ts
@@ -14,33 +14,26 @@ import { unstoppable } from './connectors/unstoppable';
 import { onto } from './connectors/onto';
 import { gnosisSafe } from './connectors/gnosisSafe';
 import { frontier } from './connectors/frontier';
-import { Chain } from 'wagmi';
 import { zerion } from './connectors/zerion';
 
-export const getWallets = ({
-  chains,
-}: {
-  chains: Chain[];
-  appName?: string;
-  shimDisconnect?: boolean;
-}) => {
+export const getWallets = () => {
   return [
-    injected({ chains }),
-    walletConnect({ chains }),
-    metaMask({ chains }),
-    coinbaseWallet({ chains }),
-    rainbow({ chains }),
-    argent({ chains }),
-    trust({ chains }),
-    ledger({ chains }),
-    imToken({ chains }),
-    brave({ chains }),
-    gnosisSafe({ chains }),
-    unstoppable({ chains }),
-    steak({ chains }),
-    //slope({ chains }),
-    onto({ chains }),
-    frontier({ chains }),
-    zerion({ chains }),
+    injected(),
+    walletConnect(),
+    metaMask(),
+    coinbaseWallet(),
+    rainbow(),
+    argent(),
+    trust(),
+    ledger(),
+    imToken(),
+    brave(),
+    gnosisSafe(),
+    unstoppable(),
+    steak(),
+    //slope(),
+    onto(),
+    frontier(),
+    zerion(),
   ];
 };

--- a/packages/connectkit/src/wallets/useDefaultWallets.tsx
+++ b/packages/connectkit/src/wallets/useDefaultWallets.tsx
@@ -6,9 +6,6 @@ import { useConnect } from 'wagmi';
 function useDefaultWallets(): WalletProps[] | any {
   const { connectors } = useConnect();
 
-  // TODO: Find a better way to get configuration chains
-  const chains = connectors[0].chains;
-
   let defaultWallets: string[] = [];
 
   // If missing metamask or coinbasewallet connector from wagmi config, add them to this list
@@ -17,7 +14,7 @@ function useDefaultWallets(): WalletProps[] | any {
   if (!connectors.find((c) => c.id === 'coinbaseWallet'))
     defaultWallets.push('coinbaseWallet');
 
-  // Add default wallets
+  // define the order of the wallets
   defaultWallets.push(
     'rainbow',
     'argent',
@@ -27,14 +24,14 @@ function useDefaultWallets(): WalletProps[] | any {
     'brave',
     'steak',
     'unstoppable',
-    //'slope', // Removed from defaults
+    //'slope',
     'onto',
     'gnosisSafe',
     'frontier',
     'zerion'
   );
 
-  const wallets = getWallets({ chains });
+  const wallets = getWallets();
   return wallets.filter((wallet) => defaultWallets.includes(wallet.id));
 }
 

--- a/packages/connectkit/src/wallets/wallet.ts
+++ b/packages/connectkit/src/wallets/wallet.ts
@@ -1,9 +1,5 @@
 import { ReactNode } from 'react';
 import { Chain } from 'wagmi';
-import { walletConnect } from './connectors/walletConnect';
-import { metaMask } from './connectors/metaMask';
-import { coinbaseWallet } from './connectors/coinbaseWallet';
-import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect';
 
 export type WalletOptions = {
   chains: Chain[];
@@ -26,36 +22,5 @@ export type WalletProps = {
   scannable?: boolean;
   installed?: boolean;
   downloadUrls?: { [key: string]: string };
-  createConnector: () => any;
-};
-
-export const getDefaultConnectors = (chains: Chain[], appName: string) => {
-  const connectors: any = [
-    walletConnect({ chains }),
-    metaMask({ chains }),
-    coinbaseWallet({
-      chains,
-      appName,
-    }),
-    //injected({ chains }),
-  ];
-
-  return connectors.map((c: any) => {
-    return { ...c.createConnector(), ...c };
-  });
-};
-
-export const getDefaultWalletConnectConnector = (chains: Chain[]) => {
-  return new WalletConnectConnector({
-    chains,
-    options: {
-      qrcode: false,
-      version: '1',
-    },
-  });
-};
-
-export const getProviderUri = async (connector: any) => {
-  const provider: any = await connector.getProvider();
-  return provider.connector.uri;
+  createUri?: (uri: string) => string;
 };

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -10,8 +10,8 @@
       "@types/react-dom": "^18.0.0",
       "connectkit": "^1.1.3",
       "ethers": "^5.6.5",
-      "typescript": "^4.4.2",
-      "wagmi": "^0.10.11",
+      "typescript": "^4.9.5",
+      "wagmi": "^0.11.3",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -9,9 +9,9 @@
       "@types/react": "^18.0.0",
       "@types/react-dom": "^18.0.0",
       "connectkit": "^1.1.3",
-      "ethers": "^5.6.5",
+      "ethers": "^5.7.1",
       "typescript": "^4.9.5",
-      "wagmi": "^0.11.4",
+      "wagmi": "^0.11.5",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -11,7 +11,7 @@
       "connectkit": "^1.1.3",
       "ethers": "^5.6.5",
       "typescript": "^4.9.5",
-      "wagmi": "^0.11.3",
+      "wagmi": "^0.11.4",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,28 +1798,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/wallet-sdk@npm:^3.6.0":
-  version: 3.6.2
-  resolution: "@coinbase/wallet-sdk@npm:3.6.2"
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
   dependencies:
-    "@metamask/safe-event-emitter": 2.0.0
-    "@solana/web3.js": 1.52.0
-    bind-decorator: ^1.0.11
-    bn.js: ^5.1.1
-    buffer: ^6.0.3
-    clsx: ^1.1.0
-    eth-block-tracker: 4.4.3
-    eth-json-rpc-filters: 4.2.2
-    eth-rpc-errors: 4.0.2
-    json-rpc-engine: 6.1.0
-    keccak: ^3.0.1
-    preact: ^10.5.9
-    qs: ^6.10.3
-    rxjs: ^6.6.3
-    sha.js: ^2.4.11
-    stream-browserify: ^3.0.0
-    util: ^0.12.4
-  checksum: 5469873e9f484df224076359b7ced587a3ffc2970239a6ceee38a2292c67c6d3b400b358f349d99f62dccc0a0de13d0d2db342c83399bb3c8f8f3f0b595c39d4
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
   languageName: node
   linkType: hard
 
@@ -2349,7 +2333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/sha2@npm:5.7.0, @ethersproject/sha2@npm:^5.5.0, @ethersproject/sha2@npm:^5.7.0":
+"@ethersproject/sha2@npm:5.7.0, @ethersproject/sha2@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/sha2@npm:5.7.0"
   dependencies:
@@ -2866,6 +2850,16 @@ __metadata:
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -3609,31 +3603,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/web3.js@npm:1.52.0":
-  version: 1.52.0
-  resolution: "@solana/web3.js@npm:1.52.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    "@ethersproject/sha2": ^5.5.0
-    "@solana/buffer-layout": ^4.0.0
-    bigint-buffer: ^1.1.5
-    bn.js: ^5.0.0
-    borsh: ^0.7.0
-    bs58: ^4.0.1
-    buffer: 6.0.1
-    fast-stable-stringify: ^1.0.0
-    jayson: ^3.4.4
-    js-sha3: ^0.8.0
-    node-fetch: 2
-    react-native-url-polyfill: ^1.3.0
-    rpc-websockets: ^7.5.0
-    secp256k1: ^4.0.2
-    superstruct: ^0.14.2
-    tweetnacl: ^1.0.3
-  checksum: be162bc31ea9a9f3e025e740f077bba2164ca6882e211fa5f694407cf44fac5038c8149691d12c5170cf4cca5a3c7adb82c04f0b34bdbc3d1429d7db21d3ba8f
-  languageName: node
-  linkType: hard
-
 "@solana/web3.js@npm:^1.70.1":
   version: 1.73.0
   resolution: "@solana/web3.js@npm:1.73.0"
@@ -4120,6 +4089,34 @@ __metadata:
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 11226c39b52b391719a2a92e10183e4260d9651f86edced166da1d95f39a0a1eaa470e44d14ac685ccd6d3df7e2002433782872c0feeb260d61e80f21250e65c
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node10@npm:1.0.9"
+  checksum: a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@tsconfig/node16@npm:1.0.3"
+  checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
   languageName: node
   linkType: hard
 
@@ -4817,53 +4814,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:0.1.10":
-  version: 0.1.10
-  resolution: "@wagmi/chains@npm:0.1.10"
-  checksum: 028e09f26b9bd8fc0f2a343b7b3cacd7cdbf1f3302ded3100d2bfef02bba54f3967581c6e97d510ffe5afef6c90444209d616c9a8543aca2905cef8c094532ae
+"@wagmi/chains@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@wagmi/chains@npm:0.2.5"
+  peerDependencies:
+    typescript: ">=4.9.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 9fe23d3f973dc0c07c284051aedb37308a95790af0df88eb5ec44323dc2cbbffaa0a297d3f7a0bfe2ad3e8d6631e0096df56863dccf5e91bba5eb2d5554e68cd
   languageName: node
   linkType: hard
 
-"@wagmi/connectors@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@wagmi/connectors@npm:0.1.8"
+"@wagmi/connectors@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@wagmi/connectors@npm:0.2.3"
   dependencies:
     "@coinbase/wallet-sdk": ^3.5.4
     "@ledgerhq/connect-kit-loader": ^1.0.1
     "@walletconnect/ethereum-provider": ^1.8.0
-    "@walletconnect/universal-provider": ^2.2.1
-    "@web3modal/standalone": ^2.0.0-rc.2
-    abitype: ^0.1.8
+    "@walletconnect/universal-provider": ^2.3.3
+    "@web3modal/standalone": ^2.0.0
+    abitype: ^0.3.0
     eventemitter3: ^4.0.7
   peerDependencies:
-    "@wagmi/core": 0.8.x
-    ethers: ^5.0.0
+    "@wagmi/core": ">=0.9.x"
+    ethers: ">=5.5.1"
+    typescript: ">=4.9.4"
   peerDependenciesMeta:
     "@wagmi/core":
       optional: true
-  checksum: 1a7b959ca924b3c6f69f696ff55f48de3b836e2a7e6e39462674b29a6d0297991a030c5f188d64db3fd0a4114a15e0243259df32980a9982148cdf30cd66005c
+    typescript:
+      optional: true
+  checksum: 92d57b26b1c8e9cf0ffb77707a13aa5d6037722815743dd5ea44e51f593ba9185dbdd3344e7ea21fca4350796ca00142b5e202791128c99cdae9c04cc928fd1f
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:0.8.15":
-  version: 0.8.15
-  resolution: "@wagmi/core@npm:0.8.15"
+"@wagmi/core@npm:0.9.3":
+  version: 0.9.3
+  resolution: "@wagmi/core@npm:0.9.3"
   dependencies:
-    "@wagmi/chains": 0.1.10
-    "@wagmi/connectors": 0.1.8
-    abitype: ^0.2.5
+    "@wagmi/chains": 0.2.5
+    "@wagmi/connectors": 0.2.3
+    abitype: ^0.3.0
     eventemitter3: ^4.0.7
     zustand: ^4.3.1
   peerDependencies:
-    "@coinbase/wallet-sdk": ">=3.6.0"
-    "@walletconnect/ethereum-provider": ">=1.7.5"
     ethers: ">=5.5.1"
+    typescript: ">=4.9.4"
   peerDependenciesMeta:
-    "@coinbase/wallet-sdk":
+    typescript:
       optional: true
-    "@walletconnect/ethereum-provider":
-      optional: true
-  checksum: 36b6f79d175dada48998a3c5535615d55872523cd45b9bda7de3e98410774196ba2f8e722210e5f6139be8ead3299017a6bc4534d1f37e6ead4e87f2b978737a
+  checksum: da7c11cdd20401e1f9f60b373a7f1c8932267a78b31700ea71f2404792d1381acd6c6589a1cf0acab94de0f612e2a8477e7098a4069f4d539de71b2fe49c1073
   languageName: node
   linkType: hard
 
@@ -4892,11 +4894,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@walletconnect/core@npm:2.2.1"
+"@walletconnect/core@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@walletconnect/core@npm:2.3.3"
   dependencies:
-    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/heartbeat": 1.2.0
     "@walletconnect/jsonrpc-provider": ^1.0.6
     "@walletconnect/jsonrpc-utils": ^1.0.4
     "@walletconnect/jsonrpc-ws-connection": ^1.0.6
@@ -4906,13 +4908,13 @@ __metadata:
     "@walletconnect/relay-auth": ^1.0.4
     "@walletconnect/safe-json": ^1.0.1
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.2.1
-    "@walletconnect/utils": 2.2.1
+    "@walletconnect/types": 2.3.3
+    "@walletconnect/utils": 2.3.3
     events: ^3.3.0
     lodash.isequal: 4.5.0
     pino: 7.11.0
     uint8arrays: 3.1.0
-  checksum: f3bdac1b62c08bc793441f41d0735c3af9cd76ab1c0a358f6ec261ef0cdd4918b80bd2d9efe49da92a70e703b5cccfe7c5454f816ee841647f72f65ef5b0cd8b
+  checksum: 231b954404626cd720fdd726d71aaf33691bb776f9d48c387c89a99258fbce24f9c1190dd0ee9a44805fa21aa1cdbd7e63d88939fc776a4ce0b2376b492460ba
   languageName: node
   linkType: hard
 
@@ -4992,14 +4994,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/heartbeat@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@walletconnect/heartbeat@npm:1.0.1"
+"@walletconnect/heartbeat@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@walletconnect/heartbeat@npm:1.2.0"
   dependencies:
     "@walletconnect/events": ^1.0.1
     "@walletconnect/time": ^1.0.2
+    chai: ^4.3.7
+    mocha: ^10.2.0
+    ts-node: ^10.9.1
     tslib: 1.14.1
-  checksum: 7591f92327cfca702eeeef277e66de036ed871b62d56dc1f8fa5f942301ca8e7e43eae4d9a1ca8399b8d433c4f6f32942af32cd9a4caca82eef4939dc484c6bb
+  checksum: 27a0efa0a9e3e073ae824dff4480b13ee878e09f949c0c18cb1cc344163ea501b3ef2602901e50062d5e7dba348632405de7f07a83313d2acce203a11a8b1a40
   languageName: node
   linkType: hard
 
@@ -5211,22 +5216,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/sign-client@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@walletconnect/sign-client@npm:2.2.1"
+"@walletconnect/sign-client@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@walletconnect/sign-client@npm:2.3.3"
   dependencies:
-    "@walletconnect/core": 2.2.1
+    "@walletconnect/core": 2.3.3
     "@walletconnect/events": ^1.0.1
-    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/heartbeat": 1.2.0
     "@walletconnect/jsonrpc-provider": ^1.0.6
     "@walletconnect/jsonrpc-utils": ^1.0.4
     "@walletconnect/logger": ^2.0.1
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.2.1
-    "@walletconnect/utils": 2.2.1
+    "@walletconnect/types": 2.3.3
+    "@walletconnect/utils": 2.3.3
     events: ^3.3.0
     pino: 7.11.0
-  checksum: 6dc558a6c9070463c94e77f46dfb0f6d457fcf02cda6f01cea8d4179a6c673884d1dc01544c4938458f64846cab4a17c80c549f782e7ec8bb8d82741da564886
+  checksum: 1830fbe41057a63da8ecf85f938c88359e1d4f3ad0dfddfed5222ebd7beda1a77af362cc8c1e0d8aca59194fb46b09baeb9fb775c65d7058d489f26fe10bd271
   languageName: node
   linkType: hard
 
@@ -5264,17 +5269,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@walletconnect/types@npm:2.2.1"
+"@walletconnect/types@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@walletconnect/types@npm:2.3.3"
   dependencies:
     "@walletconnect/events": ^1.0.1
-    "@walletconnect/heartbeat": ^1.0.1
+    "@walletconnect/heartbeat": 1.2.0
     "@walletconnect/jsonrpc-types": ^1.0.2
     "@walletconnect/keyvaluestorage": ^1.0.2
     "@walletconnect/logger": ^2.0.1
     events: ^3.3.0
-  checksum: 187335d0b2d860cad7ed3687b05db7e09fab70657e206736becd4341f2e3cf3860ea783fabe5094353ba600ec3477f65570523b25d3b72f6899d335c5680d8e6
+  checksum: 2c288ad5bde249d8522c1f3168d6dfcae50aac4fda3865919227138a37ac12fd76bbf3c1bf2a9dd176c9782317993fbcc494f85874106715f337547a87ff5e3b
   languageName: node
   linkType: hard
 
@@ -5285,28 +5290,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/universal-provider@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "@walletconnect/universal-provider@npm:2.2.1"
+"@walletconnect/universal-provider@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@walletconnect/universal-provider@npm:2.3.3"
   dependencies:
     "@walletconnect/jsonrpc-http-connection": ^1.0.4
     "@walletconnect/jsonrpc-provider": ^1.0.6
     "@walletconnect/jsonrpc-types": ^1.0.2
     "@walletconnect/jsonrpc-utils": ^1.0.4
     "@walletconnect/logger": ^2.0.1
-    "@walletconnect/sign-client": 2.2.1
-    "@walletconnect/types": 2.2.1
-    "@walletconnect/utils": 2.2.1
+    "@walletconnect/sign-client": 2.3.3
+    "@walletconnect/types": 2.3.3
+    "@walletconnect/utils": 2.3.3
     eip1193-provider: 1.0.1
     events: ^3.3.0
     pino: 7.11.0
-  checksum: 8513176f7a3ec7cfbb663ceea262e420bf081b14fa0683088caa23b825f6442a85e0b536bfe263da4c4393c33b1848eb593e51132788e570bca2e858b3f84cb2
+  checksum: 09b95373219321d9032aa69e5a67a8354634b23be8ce210008ef93f9dfa8bf1feaf410a2fb19ce34e8fc511d610477677a4795a5000e173221d3b1021073c862
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.2.1":
-  version: 2.2.1
-  resolution: "@walletconnect/utils@npm:2.2.1"
+"@walletconnect/utils@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@walletconnect/utils@npm:2.3.3"
   dependencies:
     "@stablelib/chacha20poly1305": 1.0.1
     "@stablelib/hkdf": 1.0.1
@@ -5317,13 +5322,13 @@ __metadata:
     "@walletconnect/relay-api": ^1.0.7
     "@walletconnect/safe-json": ^1.0.1
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.2.1
+    "@walletconnect/types": 2.3.3
     "@walletconnect/window-getters": ^1.0.1
     "@walletconnect/window-metadata": ^1.0.1
     detect-browser: 5.3.0
     query-string: 7.1.1
     uint8arrays: 3.1.0
-  checksum: 3a506e84dbe394ca934356821b46d0e10a1f34f73f7fac0ba9c048bb72b6a2c60c10b41c6ab59997d6242c1dff99289ecaac649b199fac24fc527eb3da509635
+  checksum: d90420bc00c871e4a955caa7095fad1de607ef31021370601cddf4d917c6f917aba13cb3ba4cb41d7228004a9a198d60f78fee44856cf8d21d82c7367b1eecec
   languageName: node
   linkType: hard
 
@@ -5377,35 +5382,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@web3modal/core@npm:2.0.0-rc.3":
-  version: 2.0.0-rc.3
-  resolution: "@web3modal/core@npm:2.0.0-rc.3"
+"@web3modal/core@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@web3modal/core@npm:2.1.1"
   dependencies:
     buffer: 6.0.3
-    valtio: 1.8.2
-  checksum: 0cfe0cb6654a143a4646a6d264593a7144272593f7d3ce18e6bb89cef1a93d8dc6ea5d34cd6906d3b1181a4dee22c939558e767a00e9d0abc6f9de12829c06db
+    valtio: 1.9.0
+  checksum: a46502e6dc17771928462dcc64e17ac3179b219cb2ef5cd2d2ca9ed1806eb7cc0895437962884222e604c6421af8f537435e610e4dfcb21b53159eca5ac32410
   languageName: node
   linkType: hard
 
-"@web3modal/standalone@npm:^2.0.0-rc.2":
-  version: 2.0.0-rc.3
-  resolution: "@web3modal/standalone@npm:2.0.0-rc.3"
+"@web3modal/standalone@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@web3modal/standalone@npm:2.1.1"
   dependencies:
-    "@web3modal/core": 2.0.0-rc.3
-    "@web3modal/ui": 2.0.0-rc.3
-  checksum: f7f7393597c816f83ae1b84124155db9fe8c8e6f64954ca847a300b64418bffa4d9c2029d78cc1e67ed824ce8d3b0c5d57dfb0922d7e6a86cb3d211d4d6e1fc5
+    "@web3modal/core": 2.1.1
+    "@web3modal/ui": 2.1.1
+  checksum: 2b5d2623baacb31ea1a897e89a9b4faccdb53ca11687789ca78b79062e3f133090d731ea63a68a7ab0c8b3951b5c7c3c203678ba158ccf4c463860e946bcde16
   languageName: node
   linkType: hard
 
-"@web3modal/ui@npm:2.0.0-rc.3":
-  version: 2.0.0-rc.3
-  resolution: "@web3modal/ui@npm:2.0.0-rc.3"
+"@web3modal/ui@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@web3modal/ui@npm:2.1.1"
   dependencies:
-    "@web3modal/core": 2.0.0-rc.3
+    "@web3modal/core": 2.1.1
     lit: 2.6.1
     motion: 10.15.5
     qrcode: 1.5.1
-  checksum: fe8d76fd17933efb7cb78c3e5eaf310b5726b575c5d3c8597496660032873c25bccb602d84a591f175886cb49cad6cf69e1b167d0cdd7c1dd5de41187a37611e
+  checksum: e32491dbaea598c8b7ec86af4aaf1adb0a4ecfd7d6726dbe859c128cf256d47cbfd06b615001f9d109e3c30ae63ecb644f6956a38c9cebac137c9a5bcd6d97dd
   languageName: node
   linkType: hard
 
@@ -5600,25 +5605,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:^0.1.8":
-  version: 0.1.8
-  resolution: "abitype@npm:0.1.8"
+"abitype@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "abitype@npm:0.3.0"
   peerDependencies:
-    typescript: ">=4.7.4"
-  checksum: 75db603ca20adaafd66c1097ab190cde333868ce5d5328b670574bd7e99dea92d1857eb5ff24405e4828c7cdaa0fec88142a4cff7883523b8ea2b8c328e8be45
-  languageName: node
-  linkType: hard
-
-"abitype@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "abitype@npm:0.2.5"
-  peerDependencies:
-    typescript: ">=4.7.4"
+    typescript: ">=4.9.4"
     zod: ">=3.19.1"
   peerDependenciesMeta:
     zod:
       optional: true
-  checksum: 46d2060d3b89ef49a88059fa0251eadf744f013246b1682f867d1657f695075da7d736caa61e6b427613e508cd691bbed5794321bd7e5862e6a46dd18e7aad3e
+  checksum: d7f604d917d0ffddc0a7865c24db78585d257202500a70b99c63da659fe299148778fcb78b31e9dbc2d213d69475880702cb05be22eaa0a49e22c73672dd97e1
   languageName: node
   linkType: hard
 
@@ -5678,6 +5674,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^7.0.0, acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
@@ -5693,6 +5696,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.4.1":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
   languageName: node
   linkType: hard
 
@@ -5812,6 +5824,13 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 5e0ff226806763be73e93dd7805b634f6f5921e3e90ca04acdf8db81eed9d8d3f0d4c5f1213047f45ebbf8047ffe0c840fa1ef2ec42c3a644899f69aa72b5bef
+  languageName: node
+  linkType: hard
+
+"ansi-colors@npm:4.1.1":
+  version: 4.1.1
+  resolution: "ansi-colors@npm:4.1.1"
+  checksum: 138d04a51076cb085da0a7e2d000c5c0bb09f6e772ed5c65c53cb118d37f6c5f1637506d7155fb5f330f0abcf6f12fa2e489ac3f8cdab9da393bf1bb4f9a32b0
   languageName: node
   linkType: hard
 
@@ -5938,6 +5957,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 52590c24860fa7173bedeb69a4c05fb573473e860197f618b9a28432ee4379049336727ae3a1f9c4cb083114601c1140cee578376164d0e651217a9843f9fe83
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -6074,6 +6100,13 @@ __metadata:
     pvutils: ^1.1.3
     tslib: ^2.4.0
   checksum: 3b6af1bbadd5762ef8ead5daf2f6bda1bc9e23bc825c4dcc996aa1f9521ad7390a64028565d95d98090d69c8431f004c71cccb866004759169d7c203cf9075eb
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "assertion-error@npm:1.1.0"
+  checksum: fd9429d3a3d4fd61782eb3962ae76b6d08aa7383123fca0596020013b3ebd6647891a85b05ce821c47d1471ed1271f00b0545cf6a4326cf2fc91efcc3b0fbecf
   languageName: node
   linkType: hard
 
@@ -6613,6 +6646,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-stdout@npm:1.3.1":
+  version: 1.3.1
+  resolution: "browser-stdout@npm:1.3.1"
+  checksum: b717b19b25952dd6af483e368f9bcd6b14b87740c3d226c2977a65e84666ffd67000bddea7d911f111a9b6ddc822b234de42d52ab6507bce4119a4cc003ef7b3
+  languageName: node
+  linkType: hard
+
 "browserify-aes@npm:^1.2.0":
   version: 1.2.0
   resolution: "browserify-aes@npm:1.2.0"
@@ -6856,7 +6896,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.2.0, camelcase@npm:^6.2.1":
+"camelcase@npm:^6.0.0, camelcase@npm:^6.2.0, camelcase@npm:^6.2.1":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -6900,6 +6940,21 @@ __metadata:
   version: 2.4.0
   resolution: "case-sensitive-paths-webpack-plugin@npm:2.4.0"
   checksum: bcf469446eeee9ac0046e30860074ebb9aa4803aab9140e6bb72b600b23b1d70635690754be4504ce35cd99cdf05226bee8d894ba362a3f5485d5f6310fc6d02
+  languageName: node
+  linkType: hard
+
+"chai@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "chai@npm:4.3.7"
+  dependencies:
+    assertion-error: ^1.1.0
+    check-error: ^1.0.2
+    deep-eql: ^4.1.2
+    get-func-name: ^2.0.0
+    loupe: ^2.3.1
+    pathval: ^1.1.1
+    type-detect: ^4.0.5
+  checksum: 0bba7d267848015246a66995f044ce3f0ebc35e530da3cbdf171db744e14cbe301ab913a8d07caf7952b430257ccbb1a4a983c570a7c5748dc537897e5131f7c
   languageName: node
   linkType: hard
 
@@ -6979,6 +7034,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"check-error@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "check-error@npm:1.0.2"
+  checksum: d9d106504404b8addd1ee3f63f8c0eaa7cd962a1a28eb9c519b1c4a1dc7098be38007fc0060f045ee00f075fbb7a2a4f42abcf61d68323677e11ab98dc16042e
+  languageName: node
+  linkType: hard
+
 "check-types@npm:^11.1.1":
   version: 11.1.2
   resolution: "check-types@npm:11.1.2"
@@ -6986,7 +7048,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.2, chokidar@npm:^3.5.3":
+"chokidar@npm:3.5.3, chokidar@npm:^3.4.2, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -7305,7 +7367,7 @@ __metadata:
     "@types/react-dom": ^18.0.2
     iron-session: ^6.2.1
     siwe: ^1.1.6
-    typescript: ^4.6.3
+    typescript: ^4.9.5
   peerDependencies:
     connectkit: "*"
     next: 12.x
@@ -7332,12 +7394,12 @@ __metadata:
     react-use-measure: ^2.1.1
     resize-observer-polyfill: ^1.5.1
     styled-components: ^5.3.5
-    typescript: ^4.6.3
+    typescript: ^4.9.5
   peerDependencies:
     ethers: ">=5.5.0 <6"
     react: 17.x || 18.x
     react-dom: 17.x || 18.x
-    wagmi: 0.10.x
+    wagmi: ">=0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -7474,8 +7536,8 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     react-scripts: 5.0.1
-    typescript: ^4.8.3
-    wagmi: ^0.10.11
+    typescript: ^4.9.5
+    wagmi: ^0.11.3
     web-vitals: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -7504,6 +7566,13 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: ba12bb2257b585a0396108c72830e85f882ab659c3320c83584b1037f8ab72415095167ced80dc4ce8e446a8ecc4b2acf36d87befe0707d73b26cf9dc77440ed
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
   languageName: node
   linkType: hard
 
@@ -7908,7 +7977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -7946,6 +8015,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decamelize@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "decamelize@npm:4.0.0"
+  checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.2.1":
   version: 10.4.1
   resolution: "decimal.js@npm:10.4.1"
@@ -7964,6 +8040,15 @@ __metadata:
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
   checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^4.1.2":
+  version: 4.1.3
+  resolution: "deep-eql@npm:4.1.3"
+  dependencies:
+    type-detect: ^4.0.0
+  checksum: 7f6d30cb41c713973dc07eaadded848b2ab0b835e518a88b91bea72f34e08c4c71d167a722a6f302d3a6108f05afd8e6d7650689a84d5d29ec7fe6220420397f
   languageName: node
   linkType: hard
 
@@ -8144,6 +8229,20 @@ __metadata:
   version: 29.0.0
   resolution: "diff-sequences@npm:29.0.0"
   checksum: 2c084a3db03ecde26f649f6f2559974e01e174451debeb301a7e17199e73423a8e8ddeb9a35ae38638c084b4fa51296a4a20fa7f44f3db0c0ba566bdc704ed3d
+  languageName: node
+  linkType: hard
+
+"diff@npm:5.0.0":
+  version: 5.0.0
+  resolution: "diff@npm:5.0.0"
+  checksum: f19fe29284b633afdb2725c2a8bb7d25761ea54d321d8e67987ac851c5294be4afeab532bd84531e02583a3fe7f4014aa314a3eda84f5590e7a9e6b371ef3b46
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -8831,6 +8930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:4.0.0, escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 98b48897d93060f2322108bf29db0feba7dd774be96cd069458d1453347b25ce8682ecc39859d4bca2203cc0ab19c237bcc71755eff49a0f8d90beadeeba5cc5
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
@@ -8842,13 +8948,6 @@ __metadata:
   version: 2.0.0
   resolution: "escape-string-regexp@npm:2.0.0"
   checksum: 9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "escape-string-regexp@npm:4.0.0"
-  checksum: 98b48897d93060f2322108bf29db0feba7dd774be96cd069458d1453347b25ce8682ecc39859d4bca2203cc0ab19c237bcc71755eff49a0f8d90beadeeba5cc5
   languageName: node
   linkType: hard
 
@@ -9675,7 +9774,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.34.0
     rollup-plugin-visualizer: ^5.5.4
     tslib: ^1.9.3
-    wagmi: ^0.10.11
+    wagmi: ^0.11.3
   languageName: unknown
   linkType: soft
 
@@ -9847,6 +9946,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:5.0.0, find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: ^6.0.0
+    path-exists: ^4.0.0
+  checksum: 07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^3.0.0":
   version: 3.0.0
   resolution: "find-up@npm:3.0.0"
@@ -9863,16 +9972,6 @@ __metadata:
     locate-path: ^5.0.0
     path-exists: ^4.0.0
   checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
-  languageName: node
-  linkType: hard
-
-"find-up@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "find-up@npm:5.0.0"
-  dependencies:
-    locate-path: ^6.0.0
-    path-exists: ^4.0.0
-  checksum: 07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
   languageName: node
   linkType: hard
 
@@ -9893,6 +9992,15 @@ __metadata:
     flatted: ^3.1.0
     rimraf: ^3.0.2
   checksum: 4fdd10ecbcbf7d520f9040dd1340eb5dfe951e6f0ecf2252edeec03ee68d989ec8b9a20f4434270e71bcfd57800dc09b3344fca3966b2eb8f613072c7d9a2365
+  languageName: node
+  linkType: hard
+
+"flat@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "flat@npm:5.0.2"
+  bin:
+    flat: cli.js
+  checksum: 12a1536ac746db74881316a181499a78ef953632ddd28050b7a3a43c62ef5462e3357c8c29d76072bb635f147f7a9a1f0c02efef6b4be28f8db62ceb3d5c7f5d
   languageName: node
   linkType: hard
 
@@ -10158,6 +10266,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-func-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "get-func-name@npm:2.0.0"
+  checksum: 8d82e69f3e7fab9e27c547945dfe5cc0c57fc0adf08ce135dddb01081d75684a03e7a0487466f478872b341d52ac763ae49e660d01ab83741f74932085f693c3
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.0, get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3":
   version: 1.1.3
   resolution: "get-intrinsic@npm:1.1.3"
@@ -10236,6 +10351,20 @@ __metadata:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: b61f48973bbdcf5159997b0874a2165db572b368b931135832599875919c237fc05c12984e38fe828e69aa8a921eb0e8a4997266211c517c9cfaae8a93988bb8
+  languageName: node
+  linkType: hard
+
+"glob@npm:7.2.0":
+  version: 7.2.0
+  resolution: "glob@npm:7.2.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
   languageName: node
   linkType: hard
 
@@ -10459,7 +10588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"he@npm:^1.2.0":
+"he@npm:1.2.0, he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
   bin:
@@ -11122,6 +11251,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
+  languageName: node
+  linkType: hard
+
 "is-plain-obj@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-plain-obj@npm:3.0.0"
@@ -11220,6 +11356,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
   languageName: node
   linkType: hard
 
@@ -12018,7 +12161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sha3@npm:0.8.0, js-sha3@npm:^0.8.0":
+"js-sha3@npm:0.8.0":
   version: 0.8.0
   resolution: "js-sha3@npm:0.8.0"
   checksum: 75df77c1fc266973f06cce8309ce010e9e9f07ec35ab12022ed29b7f0d9c8757f5a73e1b35aa24840dced0dea7059085aa143d817aea9e188e2a80d569d9adce
@@ -12032,6 +12175,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
@@ -12041,17 +12195,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: ^2.0.1
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
   languageName: node
   linkType: hard
 
@@ -12535,6 +12678,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:4.1.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: ^4.1.0
+    is-unicode-supported: ^0.1.0
+  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -12543,6 +12696,15 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^2.3.1":
+  version: 2.3.6
+  resolution: "loupe@npm:2.3.6"
+  dependencies:
+    get-func-name: ^2.0.0
+  checksum: cc83f1b124a1df7384601d72d8d1f5fe95fd7a8185469fec48bb2e4027e45243949e7a013e8d91051a138451ff0552310c32aa9786e60b6a30d1e801bdc2163f
   languageName: node
   linkType: hard
 
@@ -12614,6 +12776,13 @@ __metadata:
   dependencies:
     semver: ^6.0.0
   checksum: 484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+  languageName: node
+  linkType: hard
+
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
   languageName: node
   linkType: hard
 
@@ -12835,6 +13004,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:5.0.1":
+  version: 5.0.1
+  resolution: "minimatch@npm:5.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: b34b98463da4754bc526b244d680c69d4d6089451ebe512edaf6dd9eeed0279399cfa3edb19233513b8f830bf4bfcad911dddcdf125e75074100d52f724774f0
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -12968,6 +13146,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mocha@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "mocha@npm:10.2.0"
+  dependencies:
+    ansi-colors: 4.1.1
+    browser-stdout: 1.3.1
+    chokidar: 3.5.3
+    debug: 4.3.4
+    diff: 5.0.0
+    escape-string-regexp: 4.0.0
+    find-up: 5.0.0
+    glob: 7.2.0
+    he: 1.2.0
+    js-yaml: 4.1.0
+    log-symbols: 4.1.0
+    minimatch: 5.0.1
+    ms: 2.1.3
+    nanoid: 3.3.3
+    serialize-javascript: 6.0.0
+    strip-json-comments: 3.1.1
+    supports-color: 8.1.1
+    workerpool: 6.2.1
+    yargs: 16.2.0
+    yargs-parser: 20.2.4
+    yargs-unparser: 2.0.0
+  bin:
+    _mocha: bin/_mocha
+    mocha: bin/mocha.js
+  checksum: 406c45eab122ffd6ea2003c2f108b2bc35ba036225eee78e0c784b6fa2c7f34e2b13f1dbacef55a4fdf523255d76e4f22d1b5aacda2394bd11666febec17c719
+  languageName: node
+  linkType: hard
+
 "motion@npm:10.15.5":
   version: 10.15.5
   resolution: "motion@npm:10.15.5"
@@ -13019,6 +13229,15 @@ __metadata:
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: d3e8c1be400c09a014f557ea02251a2710dbc9fca5aa32cc702ff29f636c5471e17979f30bdcb0a9cbb556f162a8591dc2e1219c24fc21394a56115b820bb84e
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:3.3.3":
+  version: 3.3.3
+  resolution: "nanoid@npm:3.3.3"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: ada019402a07464a694553c61d2dca8a4353645a7d92f2830f0d487fedff403678a0bee5323a46522752b2eab95a0bc3da98b6cccaa7c0c55cd9975130e6d6f0
   languageName: node
   linkType: hard
 
@@ -13204,8 +13423,8 @@ __metadata:
     next: 12.3.0
     react: ^18.0.0
     react-dom: ^18.0.0
-    typescript: 4.8.3
-    wagmi: ^0.10.11
+    typescript: ^4.9.5
+    wagmi: ^0.11.3
   languageName: unknown
   linkType: soft
 
@@ -13778,6 +13997,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pathval@npm:1.1.1"
+  checksum: 090e3147716647fb7fb5b4b8c8e5b55e5d0a6086d085b6cd23f3d3c01fcf0ff56fd3cc22f2f4a033bd2e46ed55d61ed8379e123b42afe7d531a2a5fc8bb556d6
   languageName: node
   linkType: hard
 
@@ -15241,17 +15467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-url-polyfill@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "react-native-url-polyfill@npm:1.3.0"
-  dependencies:
-    whatwg-url-without-unicode: 8.0.0-3
-  peerDependencies:
-    react-native: "*"
-  checksum: 24ef81493a642b9359c1e8048de4da84fb554ffcf35677f9d8b11956d700faa4b9ac9d74f56aee67dd8d8b4ef6d9879e7431848785880ada657f8bec0211b00a
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.11.0":
   version: 0.11.0
   resolution: "react-refresh@npm:0.11.0"
@@ -16054,7 +16269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secp256k1@npm:^4.0.1, secp256k1@npm:^4.0.2":
+"secp256k1@npm:^4.0.1":
   version: 4.0.3
   resolution: "secp256k1@npm:4.0.3"
   dependencies:
@@ -16132,21 +16347,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-javascript@npm:6.0.0, serialize-javascript@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "serialize-javascript@npm:6.0.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
+  languageName: node
+  linkType: hard
+
 "serialize-javascript@npm:^4.0.0":
   version: 4.0.0
   resolution: "serialize-javascript@npm:4.0.0"
   dependencies:
     randombytes: ^2.1.0
   checksum: 3273b3394b951671fcf388726e9577021870dfbf85e742a1183fb2e91273e6101bdccea81ff230724f6659a7ee4cef924b0ff9baca32b79d9384ec37caf07302
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "serialize-javascript@npm:6.0.0"
-  dependencies:
-    randombytes: ^2.1.0
-  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
   languageName: node
   linkType: hard
 
@@ -16824,7 +17039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.0, strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.0, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
@@ -16921,6 +17136,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:8.1.1, supports-color@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: ^4.0.0
+  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -16943,15 +17167,6 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: 3dda818de06ebbe5b9653e07842d9479f3555ebc77e9a0280caf5a14fb877ffee9ed57007c3b78f5a6324b8dbeec648d9e97a24e2ed9fdb81ddc69ea07100f4a
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^8.0.0":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: ^4.0.0
-  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
   languageName: node
   linkType: hard
 
@@ -17188,8 +17403,8 @@ __metadata:
     next: 13.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
-    typescript: 4.8.3
-    wagmi: ^0.10.11
+    typescript: ^4.9.5
+    wagmi: ^0.11.3
   languageName: unknown
   linkType: soft
 
@@ -17334,6 +17549,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.1":
+  version: 10.9.1
+  resolution: "ts-node@npm:10.9.1"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
@@ -17388,13 +17641,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tweetnacl@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tweetnacl@npm:1.0.3"
-  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
-  languageName: node
-  linkType: hard
-
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -17413,7 +17659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
@@ -17481,43 +17727,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8.3":
-  version: 4.8.3
-  resolution: "typescript@npm:4.8.3"
+"typescript@npm:^4.9.5":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.3, typescript@npm:^4.6.4, typescript@npm:^4.8.3":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.8.3#~builtin<compat/typescript>":
-  version: 4.8.3
-  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=a1c5e5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 2222d2382fb3146089b1d27ce2b55e9d1f99cc64118f1aba75809b693b856c5d3c324f052f60c75b577947fc538bc1c27bad0eb76cbdba9a63a253489504ba7e
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.3#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=a1c5e5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
   languageName: node
   linkType: hard
 
@@ -17766,6 +17992,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^8.1.0":
   version: 8.1.1
   resolution: "v8-to-istanbul@npm:8.1.1"
@@ -17787,9 +18020,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valtio@npm:1.8.2":
-  version: 1.8.2
-  resolution: "valtio@npm:1.8.2"
+"valtio@npm:1.9.0":
+  version: 1.9.0
+  resolution: "valtio@npm:1.9.0"
   dependencies:
     proxy-compare: 2.4.0
     use-sync-external-store: 1.2.0
@@ -17798,7 +18031,7 @@ __metadata:
   peerDependenciesMeta:
     react:
       optional: true
-  checksum: 58e271988e70afe0dd5ac2c66c54e653f97010afc2439401aac449b50f903b8617a6920038e3585624817abedcffeb541093036983cba2ce8a6212c7d65f8454
+  checksum: baf07b9130d6fc27b542b0a06a02a788c3cf85bbe4709a765655ac4a66ade016681ff368e0434aceb98925c80747928530842a939f23a1f916b3f81c2b2a1a65
   languageName: node
   linkType: hard
 
@@ -17852,9 +18085,9 @@ __metadata:
     ethers: ^5.6.5
     react: ^18.2.0
     react-dom: ^18.2.0
-    typescript: ^4.6.4
+    typescript: ^4.9.5
     vite: ^3.1.0
-    wagmi: ^0.10.11
+    wagmi: ^0.11.3
   languageName: unknown
   linkType: soft
 
@@ -17876,22 +18109,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.10.11":
-  version: 0.10.11
-  resolution: "wagmi@npm:0.10.11"
+"wagmi@npm:^0.11.3":
+  version: 0.11.3
+  resolution: "wagmi@npm:0.11.3"
   dependencies:
-    "@coinbase/wallet-sdk": ^3.6.0
     "@tanstack/query-sync-storage-persister": ^4.14.5
     "@tanstack/react-query": ^4.14.5
     "@tanstack/react-query-persist-client": ^4.14.5
-    "@wagmi/core": 0.8.15
-    "@walletconnect/ethereum-provider": ^1.8.0
-    abitype: ^0.2.5
+    "@wagmi/core": 0.9.3
+    abitype: ^0.3.0
     use-sync-external-store: ^1.2.0
   peerDependencies:
     ethers: ">=5.5.1"
     react: ">=17.0.0"
-  checksum: fe901f541e2b533968d86df31b8f29ad8bb44269018b95ca0f3d2724e2c425d855fb18a1320061669e2fa1503c9bd9749655b9b129908128b04cc56b73dd3768
+    typescript: ">=4.9.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: add3a260d715102cf4bc10262ac9b2257bd86f65c39ec168bebddc73d64f81613a8de74972f667bd7b05fccb1a08f1bfdcd921a38123bc7c4ded7a1db0cd0a53
   languageName: node
   linkType: hard
 
@@ -18153,17 +18388,6 @@ __metadata:
   version: 2.3.0
   resolution: "whatwg-mimetype@npm:2.3.0"
   checksum: 23eb885940bcbcca4ff841c40a78e9cbb893ec42743993a42bf7aed16085b048b44b06f3402018931687153550f9a32d259dfa524e4f03577ab898b6965e5383
-  languageName: node
-  linkType: hard
-
-"whatwg-url-without-unicode@npm:8.0.0-3":
-  version: 8.0.0-3
-  resolution: "whatwg-url-without-unicode@npm:8.0.0-3"
-  dependencies:
-    buffer: ^5.4.3
-    punycode: ^2.1.1
-    webidl-conversions: ^5.0.0
-  checksum: 1fe266f7161e0bd961087c1254a5a59d1138c3d402064495eed65e7590d9caed5a1d9acfd6e7a1b0bf0431253b0e637ee3e4ffc08387cd60e0b2ddb9d4687a4b
   languageName: node
   linkType: hard
 
@@ -18486,6 +18710,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workerpool@npm:6.2.1":
+  version: 6.2.1
+  resolution: "workerpool@npm:6.2.1"
+  checksum: c2c6eebbc5225f10f758d599a5c016fa04798bcc44e4c1dffb34050cd361d7be2e97891aa44419e7afe647b1f767b1dc0b85a5e046c409d890163f655028b09d
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^5.1.0":
   version: 5.1.0
   resolution: "wrap-ansi@npm:5.1.0"
@@ -18654,6 +18885,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:20.2.4":
+  version: 20.2.4
+  resolution: "yargs-parser@npm:20.2.4"
+  checksum: d251998a374b2743a20271c2fd752b9fbef24eb881d53a3b99a7caa5e8227fcafd9abf1f345ac5de46435821be25ec12189a11030c12ee6481fef6863ed8b924
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -18685,6 +18923,33 @@ __metadata:
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
+"yargs-unparser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "yargs-unparser@npm:2.0.0"
+  dependencies:
+    camelcase: ^6.0.0
+    decamelize: ^4.0.0
+    flat: ^5.0.2
+    is-plain-obj: ^2.1.0
+  checksum: 68f9a542c6927c3768c2f16c28f71b19008710abd6b8f8efbac6dcce26bbb68ab6503bed1d5994bdbc2df9a5c87c161110c1dfe04c6a3fe5c6ad1b0e15d9a8a3
+  languageName: node
+  linkType: hard
+
+"yargs@npm:16.2.0, yargs@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "yargs@npm:16.2.0"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^20.2.2
+  checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
   languageName: node
   linkType: hard
 
@@ -18725,21 +18990,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.2.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
-  dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.5
-    yargs-parser: ^20.2.2
-  checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
-  languageName: node
-  linkType: hard
-
 "yargs@npm:^17.1.1, yargs@npm:^17.5.1":
   version: 17.5.1
   resolution: "yargs@npm:17.5.1"
@@ -18752,6 +19002,13 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.0.0
   checksum: 00d58a2c052937fa044834313f07910fd0a115dec5ee35919e857eeee3736b21a4eafa8264535800ba8bac312991ce785ecb8a51f4d2cc8c4676d865af1cfbde
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,34 +2285,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.7.1":
-  version: 5.7.1
-  resolution: "@ethersproject/providers@npm:5.7.1"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/constants": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/networks": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/rlp": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/web": ^5.7.0
-    bech32: 1.1.4
-    ws: 7.4.6
-  checksum: 673745e967e7215b46b7d3024f5ee02be975d6cf66b605f87a0e5beaa349d6d30c987165f98eceddaf7996f64a1ec414f0715f25fc3458aead6eea4c4820c399
-  languageName: node
-  linkType: hard
-
 "@ethersproject/providers@npm:5.7.2":
   version: 5.7.2
   resolution: "@ethersproject/providers@npm:5.7.2"
@@ -7458,7 +7430,7 @@ __metadata:
     ethers: ">=5.5.0 <6"
     react: 17.x || 18.x
     react-dom: 17.x || 18.x
-    wagmi: ">=0.11.4"
+    wagmi: ">=0.11.5"
   languageName: unknown
   linkType: soft
 
@@ -7591,12 +7563,12 @@ __metadata:
     "@types/react": ^18.0.20
     "@types/react-dom": ^18.0.6
     connectkit: "workspace:packages/connectkit"
-    ethers: ^5.6.5
+    ethers: ^5.7.1
     react: ^18.0.0
     react-dom: ^18.0.0
     react-scripts: 5.0.1
     typescript: ^4.9.5
-    wagmi: ^0.11.4
+    wagmi: ^0.11.5
     web-vitals: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -9632,45 +9604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.6.5":
-  version: 5.7.1
-  resolution: "ethers@npm:5.7.1"
-  dependencies:
-    "@ethersproject/abi": 5.7.0
-    "@ethersproject/abstract-provider": 5.7.0
-    "@ethersproject/abstract-signer": 5.7.0
-    "@ethersproject/address": 5.7.0
-    "@ethersproject/base64": 5.7.0
-    "@ethersproject/basex": 5.7.0
-    "@ethersproject/bignumber": 5.7.0
-    "@ethersproject/bytes": 5.7.0
-    "@ethersproject/constants": 5.7.0
-    "@ethersproject/contracts": 5.7.0
-    "@ethersproject/hash": 5.7.0
-    "@ethersproject/hdnode": 5.7.0
-    "@ethersproject/json-wallets": 5.7.0
-    "@ethersproject/keccak256": 5.7.0
-    "@ethersproject/logger": 5.7.0
-    "@ethersproject/networks": 5.7.1
-    "@ethersproject/pbkdf2": 5.7.0
-    "@ethersproject/properties": 5.7.0
-    "@ethersproject/providers": 5.7.1
-    "@ethersproject/random": 5.7.0
-    "@ethersproject/rlp": 5.7.0
-    "@ethersproject/sha2": 5.7.0
-    "@ethersproject/signing-key": 5.7.0
-    "@ethersproject/solidity": 5.7.0
-    "@ethersproject/strings": 5.7.0
-    "@ethersproject/transactions": 5.7.0
-    "@ethersproject/units": 5.7.0
-    "@ethersproject/wallet": 5.7.0
-    "@ethersproject/web": 5.7.1
-    "@ethersproject/wordlists": 5.7.0
-  checksum: 7a61b7a105c41f9fec327887414f1950dc27bfa2d12fe29a068419eaaa3d415e6a12275685c87f700abd88c3b639ae79c09a2f90edea1e69edc8126cb0dce708
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^5.7.2":
+"ethers@npm:^5.7.1, ethers@npm:^5.7.2":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -9862,7 +9796,7 @@ __metadata:
   dependencies:
     "@changesets/cli": ^2.24.4
     "@rollup/plugin-node-resolve": ^13.1.3
-    ethers: ^5.6.5
+    ethers: ^5.7.1
     react: ^18.0.0
     react-dom: ^18.0.0
     rollup: ^2.67.1
@@ -9871,7 +9805,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.34.0
     rollup-plugin-visualizer: ^5.5.4
     tslib: ^1.9.3
-    wagmi: ^0.11.4
+    wagmi: ^0.11.5
   languageName: unknown
   linkType: soft
 
@@ -13516,12 +13450,12 @@ __metadata:
     connectkit: "workspace:packages/connectkit"
     eslint: 8.23.1
     eslint-config-next: 12.3.0
-    ethers: ^5.6.5
+    ethers: ^5.7.1
     next: 12.3.0
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: ^4.9.5
-    wagmi: ^0.11.4
+    wagmi: ^0.11.5
   languageName: unknown
   linkType: soft
 
@@ -17495,13 +17429,13 @@ __metadata:
     connectkit-next-siwe: "workspace:packages/connectkit-next-siwe"
     eslint: 8.23.1
     eslint-config-next: 12.3.0
-    ethers: ^5.6.5
+    ethers: ^5.7.1
     local-ssl-proxy: ^1.3.0
     next: 13.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: ^4.9.5
-    wagmi: ^0.11.4
+    wagmi: ^0.11.5
   languageName: unknown
   linkType: soft
 
@@ -18179,12 +18113,12 @@ __metadata:
     "@types/react-dom": ^18.0.6
     "@vitejs/plugin-react": ^2.1.0
     connectkit: "workspace:packages/connectkit"
-    ethers: ^5.6.5
+    ethers: ^5.7.1
     react: ^18.2.0
     react-dom: ^18.2.0
     typescript: ^4.9.5
     vite: ^3.1.0
-    wagmi: ^0.11.4
+    wagmi: ^0.11.5
   languageName: unknown
   linkType: soft
 
@@ -18206,7 +18140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.11.4":
+"wagmi@npm:^0.11.5":
   version: 0.11.4
   resolution: "wagmi@npm:0.11.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,6 +2313,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethersproject/providers@npm:5.7.2":
+  version: 5.7.2
+  resolution: "@ethersproject/providers@npm:5.7.2"
+  dependencies:
+    "@ethersproject/abstract-provider": ^5.7.0
+    "@ethersproject/abstract-signer": ^5.7.0
+    "@ethersproject/address": ^5.7.0
+    "@ethersproject/base64": ^5.7.0
+    "@ethersproject/basex": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/constants": ^5.7.0
+    "@ethersproject/hash": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/networks": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/random": ^5.7.0
+    "@ethersproject/rlp": ^5.7.0
+    "@ethersproject/sha2": ^5.7.0
+    "@ethersproject/strings": ^5.7.0
+    "@ethersproject/transactions": ^5.7.0
+    "@ethersproject/web": ^5.7.0
+    bech32: 1.1.4
+    ws: 7.4.6
+  checksum: 1754c731a5ca6782ae9677f4a9cd8b6246c4ef21a966c9a01b133750f3c578431ec43ec254e699969c4a0f87e84463ded50f96b415600aabd37d2056aee58c19
+  languageName: node
+  linkType: hard
+
 "@ethersproject/random@npm:5.7.0, @ethersproject/random@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/random@npm:5.7.0"
@@ -3569,6 +3597,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@safe-global/safe-apps-provider@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@safe-global/safe-apps-provider@npm:0.15.2"
+  dependencies:
+    "@safe-global/safe-apps-sdk": 7.9.0
+    events: ^3.3.0
+  checksum: 5d647d105c935f1cb2b349b2dd3f8b590be5b16f5c1e65e4fd3fb8c72e46bfe8e2bb8e4876642511c41c0b3d75ae2f572e55a35066740c04d80c1def02e93e3b
+  languageName: node
+  linkType: hard
+
+"@safe-global/safe-apps-sdk@npm:7.9.0, @safe-global/safe-apps-sdk@npm:^7.9.0":
+  version: 7.9.0
+  resolution: "@safe-global/safe-apps-sdk@npm:7.9.0"
+  dependencies:
+    "@safe-global/safe-gateway-typescript-sdk": ^3.5.3
+    ethers: ^5.7.2
+  checksum: 439cea5e486e85619c78c876bdbb81544d54c47af24e9633b7e0bd49cb0b25d260f02de573e734cd5bf767c8188bc60729880e30c86785c7e7dd22f0dbd5d0dd
+  languageName: node
+  linkType: hard
+
+"@safe-global/safe-gateway-typescript-sdk@npm:^3.5.3":
+  version: 3.7.0
+  resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.7.0"
+  dependencies:
+    cross-fetch: ^3.1.5
+  checksum: 648bac448935913890fc9b42cb27bec0deac62dce49146f6fd24ca15509987299143c00cffc5f300b8bd85bfa464230751bd1e8cda80f4ef19f67c7485c09534
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.24.1":
   version: 0.24.44
   resolution: "@sinclair/typebox@npm:0.24.44"
@@ -4814,24 +4871,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:0.2.5":
-  version: 0.2.5
-  resolution: "@wagmi/chains@npm:0.2.5"
+"@wagmi/chains@npm:0.2.6":
+  version: 0.2.6
+  resolution: "@wagmi/chains@npm:0.2.6"
   peerDependencies:
     typescript: ">=4.9.4"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 9fe23d3f973dc0c07c284051aedb37308a95790af0df88eb5ec44323dc2cbbffaa0a297d3f7a0bfe2ad3e8d6631e0096df56863dccf5e91bba5eb2d5554e68cd
+  checksum: 2c52e7725757ad7b58df522a6db9b6b628ee45d43f75842fe3f7e13eab953cea32808d90a1be37f15874958309fcb78d9d65d564516cccb719099ccb68651002
   languageName: node
   linkType: hard
 
-"@wagmi/connectors@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@wagmi/connectors@npm:0.2.3"
+"@wagmi/connectors@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@wagmi/connectors@npm:0.2.4"
   dependencies:
     "@coinbase/wallet-sdk": ^3.5.4
     "@ledgerhq/connect-kit-loader": ^1.0.1
+    "@safe-global/safe-apps-provider": ^0.15.2
+    "@safe-global/safe-apps-sdk": ^7.9.0
     "@walletconnect/ethereum-provider": ^1.8.0
     "@walletconnect/universal-provider": ^2.3.3
     "@web3modal/standalone": ^2.0.0
@@ -4839,33 +4898,33 @@ __metadata:
     eventemitter3: ^4.0.7
   peerDependencies:
     "@wagmi/core": ">=0.9.x"
-    ethers: ">=5.5.1"
+    ethers: ">=5.5.1 <6"
     typescript: ">=4.9.4"
   peerDependenciesMeta:
     "@wagmi/core":
       optional: true
     typescript:
       optional: true
-  checksum: 92d57b26b1c8e9cf0ffb77707a13aa5d6037722815743dd5ea44e51f593ba9185dbdd3344e7ea21fca4350796ca00142b5e202791128c99cdae9c04cc928fd1f
+  checksum: 086a02a3e085ac65845c6aac3e3dc1aeea4fdd0fb96cd26a2cbaf194e703818d03631dd02887160a8c7c3dfa7b25bb393b9b689e7133779203a753ec4d64748d
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:0.9.3":
-  version: 0.9.3
-  resolution: "@wagmi/core@npm:0.9.3"
+"@wagmi/core@npm:0.9.4":
+  version: 0.9.4
+  resolution: "@wagmi/core@npm:0.9.4"
   dependencies:
-    "@wagmi/chains": 0.2.5
-    "@wagmi/connectors": 0.2.3
+    "@wagmi/chains": 0.2.6
+    "@wagmi/connectors": 0.2.4
     abitype: ^0.3.0
     eventemitter3: ^4.0.7
     zustand: ^4.3.1
   peerDependencies:
-    ethers: ">=5.5.1"
+    ethers: ">=5.5.1 <6"
     typescript: ">=4.9.4"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: da7c11cdd20401e1f9f60b373a7f1c8932267a78b31700ea71f2404792d1381acd6c6589a1cf0acab94de0f612e2a8477e7098a4069f4d539de71b2fe49c1073
+  checksum: cbae5337ebcdeeb1a2bd669452e4816d7f05535556001447a7568aa83e7f0f6322f72237ed5d62c14de3f4eee50fbc72a9c6bd016628f11bace59b2380d5a72b
   languageName: node
   linkType: hard
 
@@ -7399,7 +7458,7 @@ __metadata:
     ethers: ">=5.5.0 <6"
     react: 17.x || 18.x
     react-dom: 17.x || 18.x
-    wagmi: ">=0.11.3"
+    wagmi: ">=0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -7537,7 +7596,7 @@ __metadata:
     react-dom: ^18.0.0
     react-scripts: 5.0.1
     typescript: ^4.9.5
-    wagmi: ^0.11.3
+    wagmi: ^0.11.4
     web-vitals: ^2.1.4
   languageName: unknown
   linkType: soft
@@ -7576,7 +7635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.1.4":
+"cross-fetch@npm:^3.1.4, cross-fetch@npm:^3.1.5":
   version: 3.1.5
   resolution: "cross-fetch@npm:3.1.5"
   dependencies:
@@ -9611,6 +9670,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethers@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "ethers@npm:5.7.2"
+  dependencies:
+    "@ethersproject/abi": 5.7.0
+    "@ethersproject/abstract-provider": 5.7.0
+    "@ethersproject/abstract-signer": 5.7.0
+    "@ethersproject/address": 5.7.0
+    "@ethersproject/base64": 5.7.0
+    "@ethersproject/basex": 5.7.0
+    "@ethersproject/bignumber": 5.7.0
+    "@ethersproject/bytes": 5.7.0
+    "@ethersproject/constants": 5.7.0
+    "@ethersproject/contracts": 5.7.0
+    "@ethersproject/hash": 5.7.0
+    "@ethersproject/hdnode": 5.7.0
+    "@ethersproject/json-wallets": 5.7.0
+    "@ethersproject/keccak256": 5.7.0
+    "@ethersproject/logger": 5.7.0
+    "@ethersproject/networks": 5.7.1
+    "@ethersproject/pbkdf2": 5.7.0
+    "@ethersproject/properties": 5.7.0
+    "@ethersproject/providers": 5.7.2
+    "@ethersproject/random": 5.7.0
+    "@ethersproject/rlp": 5.7.0
+    "@ethersproject/sha2": 5.7.0
+    "@ethersproject/signing-key": 5.7.0
+    "@ethersproject/solidity": 5.7.0
+    "@ethersproject/strings": 5.7.0
+    "@ethersproject/transactions": 5.7.0
+    "@ethersproject/units": 5.7.0
+    "@ethersproject/wallet": 5.7.0
+    "@ethersproject/web": 5.7.1
+    "@ethersproject/wordlists": 5.7.0
+  checksum: b7c08cf3e257185a7946117dbbf764433b7ba0e77c27298dec6088b3bc871aff711462b0621930c56880ff0a7ceb8b1d3a361ffa259f93377b48e34107f62553
+  languageName: node
+  linkType: hard
+
 "ethjs-util@npm:0.1.6, ethjs-util@npm:^0.1.3":
   version: 0.1.6
   resolution: "ethjs-util@npm:0.1.6"
@@ -9774,7 +9871,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.34.0
     rollup-plugin-visualizer: ^5.5.4
     tslib: ^1.9.3
-    wagmi: ^0.11.3
+    wagmi: ^0.11.4
   languageName: unknown
   linkType: soft
 
@@ -13424,7 +13521,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: ^4.9.5
-    wagmi: ^0.11.3
+    wagmi: ^0.11.4
   languageName: unknown
   linkType: soft
 
@@ -17404,7 +17501,7 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     typescript: ^4.9.5
-    wagmi: ^0.11.3
+    wagmi: ^0.11.4
   languageName: unknown
   linkType: soft
 
@@ -18087,7 +18184,7 @@ __metadata:
     react-dom: ^18.2.0
     typescript: ^4.9.5
     vite: ^3.1.0
-    wagmi: ^0.11.3
+    wagmi: ^0.11.4
   languageName: unknown
   linkType: soft
 
@@ -18109,24 +18206,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.11.3":
-  version: 0.11.3
-  resolution: "wagmi@npm:0.11.3"
+"wagmi@npm:^0.11.4":
+  version: 0.11.4
+  resolution: "wagmi@npm:0.11.4"
   dependencies:
     "@tanstack/query-sync-storage-persister": ^4.14.5
     "@tanstack/react-query": ^4.14.5
     "@tanstack/react-query-persist-client": ^4.14.5
-    "@wagmi/core": 0.9.3
+    "@wagmi/core": 0.9.4
     abitype: ^0.3.0
     use-sync-external-store: ^1.2.0
   peerDependencies:
-    ethers: ">=5.5.1"
+    ethers: ">=5.5.1 <6"
     react: ">=17.0.0"
     typescript: ">=4.9.4"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: add3a260d715102cf4bc10262ac9b2257bd86f65c39ec168bebddc73d64f81613a8de74972f667bd7b05fccb1a08f1bfdcd921a38123bc7c4ded7a1db0cd0a53
+  checksum: 23980fd7ced8570712015493d2bc976c22e98378c645e1fc40568a43b5056f48501ffcf824a4ceeefce2fbc2cefae60e7b3245e06b270d36e2cca88feed5e989
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Edit: closed in favour of https://github.com/family/connectkit/pull/161

A lot of the features in this PR have been merged in separately causing some unnecessary merge conflicts.
The above PR splits out these features and brings in WCv2 more elegantly.

---
**Old comment:**

This PR introduces WalletConnect v2 support.

**Notable changes:**
* Due to WalletConnect QR codes now take longer to fetch, we have introduced a placeholder loading animation before showing a QR code (WIP).
* WalletConnect v1 is still supported in this version of ConnectKit, but v1 will be ~[sunset on March 1st.](https://medium.com/walletconnect/walletconnect-v1-0-sunset-notice-and-migration-schedule-8af9d3720d2e)~ [sunset on June 28th](https://medium.com/walletconnect/weve-reset-the-clock-on-the-walletconnect-v1-0-shutdown-now-scheduled-for-june-28-2023-ead2d953b595)
* Changed `walletConnectCTA` to `link` by default.