### PR TITLE
fix: convert both addresses to same format before comparing in SIWE config `signOutOnAccountChange` case

### DIFF
--- a/packages/connectkit/src/components/Standard/SIWE/SIWEProvider.tsx
+++ b/packages/connectkit/src/components/Standard/SIWE/SIWEProvider.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useContext, useEffect } from 'react';
 import { useAccount, useQuery, useNetwork } from 'wagmi';
 import { Context as ConnectKitContext } from '../../ConnectKit';
 import { SIWEContext, SIWEConfig } from './SIWEContext';
+import { utils } from 'ethers';
 
 type Props = SIWEConfig & {
   children: ReactNode;
@@ -65,7 +66,11 @@ export const SIWEProvider = ({
     if (!connectedAddress || !chain) return;
 
     // If SIWE session no longer matches connected account, sign out
-    if (signOutOnAccountChange && sessionData.address !== connectedAddress) {
+    if (
+      signOutOnAccountChange &&
+      utils.getAddress(sessionData.address) !==
+        utils.getAddress(connectedAddress)
+    ) {
       console.warn('Wallet account changed, signing out of SIWE session');
       signOutAndRefetch();
     }


### PR DESCRIPTION
fixes https://github.com/family/connectkit/issues/111