### PR TITLE
feat: add celo to supported chains

### DIFF
--- a/packages/connectkit/src/constants/supportedChains.tsx
+++ b/packages/connectkit/src/constants/supportedChains.tsx
@@ -73,6 +73,16 @@ const supportedChains: Chain[] = [
     name: 'Arbitrum Goerli',
     logo: <Logos.Arbitrum testnet />,
   },
+  {
+    id: 42220,
+    name: 'Celo',
+    logo: <Logos.UnknownChain />,
+  },
+  {
+    id: 44787,
+    name: 'Celo Alfajores',
+    logo: <Logos.UnknownChain testnet />,
+  },
 ];
 
 export default supportedChains;


### PR DESCRIPTION
This change adds Celo mainnet and Alfajores test net to the supported chains array. These chains are both supported by Wagmi as seen in the docs [here](https://wagmi.sh/react/chains), so based on the [connectkit docs](https://docs.family.co/connectkit/chains#custom-chains-example), they should be supported too. I've looked through the code, and apart from adding the logo, there doesn't seem to be any other changes necessary to enable this.