### PR TITLE
add ledger extension connector

### DIFF
--- a/packages/connectkit/src/assets/logos.tsx
+++ b/packages/connectkit/src/assets/logos.tsx
@@ -580,7 +580,7 @@ export const Ledger = ({ ...props }) => (
     viewBox="0 0 88 88"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    style={{ background: 'black' }}
+    style={{ background: 'var(--ck-brand-ledger)' }}
   >
     <path
       fillRule="evenodd"

--- a/packages/connectkit/src/constants/supportedConnectors.tsx
+++ b/packages/connectkit/src/constants/supportedConnectors.tsx
@@ -98,6 +98,15 @@ if (typeof window != 'undefined') {
       defaultConnect: () => {},
     },
     {
+      id: 'ledger',
+      name: 'Ledger',
+      logos: {
+        default: <Logos.Ledger />,
+      },
+      logoBackground: 'var(--ck-brand-ledger)',
+      scannable: false,
+    },
+    {
       id: 'metaMask',
       name: 'MetaMask',
       logos: {

--- a/packages/connectkit/src/styles/index.ts
+++ b/packages/connectkit/src/styles/index.ts
@@ -113,6 +113,7 @@ const themeGlobals = {
     '--ck-brand-argent': '#f36a3d',
     '--ck-brand-imtoken-01': '#11C4D1',
     '--ck-brand-imtoken-02': '#0062AD',
+    '--ck-brand-ledger': '#000000',
   },
 };
 const themeColors = {


### PR DESCRIPTION
adds support for [Ledger Connect Kit](https://get-connect.ledger.com).

Ledger Connect is still in BETA at time of drafting this PR, but looks to be [launching it's extension some time this quarter](https://developers.ledger.com/docs/connect/introduction/#platforms), so we're prepping for release.

TODO:
- [ ] Detect if Ledger Connect is installed (requires more info)
- [x] Add to supported connector list
- [x] Include branding