### PR TITLE
adds Context export

### DIFF
--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -4,7 +4,7 @@ export { default as getDefaultClient, getGlobalChains } from './defaultClient';
 export { useModal } from './components/ConnectKit';
 export { SIWEProvider, useSIWE, SIWEConfig, SIWESession } from './siwe';
 
-export { ConnectKitProvider } from './components/ConnectKit';
+export { ConnectKitProvider, Context } from './components/ConnectKit';
 export { ConnectKitButton } from './components/ConnectButton';
 export { default as SIWEButton } from './components/Standard/SIWE';
 


### PR DESCRIPTION
React apps that include multiple renderers (`react-dom` + `react-three-fiber` in my case) don't automatically share context, so it ends up being necessary to reference the context manually to wire them together with [something like this](https://github.com/pmndrs/drei#usecontextbridge).

This PR just adds the Context to the package's exports.