### PR TITLE
adds: options to choose which page to navigate to when opening modal

### DIFF
--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -204,7 +204,7 @@ const Home: NextPage = () => {
   const { chain } = useNetwork();
   const chains = getGlobalChains();
 
-  const { open, setOpen, openSignInWithEthereum, openAbout } = useModal();
+  const { open, setOpen, openSIWE, openAbout } = useModal();
 
   if (!mounted) return null;
 
@@ -231,7 +231,7 @@ const Home: NextPage = () => {
         <p>useModal. open: {open.toString()}</p>
         <button onClick={() => setOpen(true)}>Open modal</button>
         <button onClick={() => openAbout()}>Open to About</button>
-        <button onClick={() => openSignInWithEthereum()}>Open to SIWE</button>
+        <button onClick={() => openSIWE(true)}>Open to SIWE</button>
 
         <hr />
         <AccountInfo />

--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -1,13 +1,14 @@
 import type { NextPage } from 'next';
 import {
-  ConnectKitButton,
   Types,
+  ConnectKitButton,
   Avatar,
-  useSIWE,
   SIWEButton,
   ChainIcon,
   getGlobalChains,
   SIWESession,
+  useModal,
+  useSIWE,
 } from 'connectkit';
 import { useTestBench } from '../TestbenchProvider';
 import { Checkbox, Textbox, Select, SelectProps } from '../components/inputs';
@@ -203,6 +204,8 @@ const Home: NextPage = () => {
   const { chain } = useNetwork();
   const chains = getGlobalChains();
 
+  const { open, setOpen, openSignInWithEthereum, openAbout } = useModal();
+
   if (!mounted) return null;
 
   return (
@@ -223,6 +226,12 @@ const Home: NextPage = () => {
           }}
         />
         <CustomSIWEButton />
+
+        <hr />
+        <p>useModal. open: {open.toString()}</p>
+        <button onClick={() => setOpen(true)}>Open modal</button>
+        <button onClick={() => openAbout()}>Open to About</button>
+        <button onClick={() => openSignInWithEthereum()}>Open to SIWE</button>
 
         <hr />
         <AccountInfo />

--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -207,7 +207,7 @@ const Modal: React.FC<ModalProps> = ({
   const context = useContext();
   const themeContext = useThemeContext();
   const mobile = isMobile();
-  const { isSignedIn } = useSIWE();
+  const { isSignedIn, reset } = useSIWE();
 
   const connector = supportedConnectors.find((x) => x.id === context.connector);
   const locales = useLocales({
@@ -503,9 +503,10 @@ const Modal: React.FC<ModalProps> = ({
                           locales.signInWithEthereumScreen_signedOut_heading
                         }
                         key="siweButton"
-                        onClick={() =>
-                          context.setRoute(routes.SIGNINWITHETHEREUM)
-                        }
+                        onClick={() => {
+                          reset();
+                          context.setRoute(routes.SIGNINWITHETHEREUM);
+                        }}
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}

--- a/packages/connectkit/src/components/ConnectButton/index.tsx
+++ b/packages/connectkit/src/components/ConnectButton/index.tsx
@@ -8,7 +8,9 @@ import {
   TextContainer,
   UnsupportedNetworkContainer,
 } from './styles';
-import { routes, useContext, useModal } from '../ConnectKit';
+import { routes, useContext } from '../ConnectKit';
+import { useModal } from '../../hooks/useModal';
+
 import Avatar from '../Common/Avatar';
 import { AnimatePresence, Variants, motion } from 'framer-motion';
 import { CustomTheme, Mode, Theme } from '../../types';

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -223,18 +223,3 @@ export const useContext = () => {
   if (!context) throw Error('ConnectKit Hook must be inside a Provider.');
   return context;
 };
-
-// Experimenal—can change later so only surface in API reference
-export const useModal = () => {
-  const context = useContext();
-  const { isConnected } = useAccount();
-  return {
-    open: context.open,
-    setOpen: (show: boolean) => {
-      if (show) {
-        context.setRoute(isConnected ? routes.PROFILE : routes.CONNECTORS);
-      }
-      context.setOpen(show);
-    },
-  };
-};

--- a/packages/connectkit/src/components/Pages/SignInWithEthereum/index.tsx
+++ b/packages/connectkit/src/components/Pages/SignInWithEthereum/index.tsx
@@ -59,11 +59,7 @@ const SignInWithEthereum: React.FC = () => {
         };
 
   useEffect(() => {
-    if (isSignedIn) {
-      setStatus('signedIn');
-    } else {
-      reset();
-    }
+    if (isSignedIn) setStatus('signedIn');
   }, []);
 
   useEffect(() => {

--- a/packages/connectkit/src/components/Standard/SIWE/index.tsx
+++ b/packages/connectkit/src/components/Standard/SIWE/index.tsx
@@ -6,7 +6,7 @@ import useIsMounted from '../../../hooks/useIsMounted';
 import useLocales from '../../../hooks/useLocales';
 import { SIWESession, useSIWE } from './../../../siwe';
 import { useAccount } from 'wagmi';
-import { useModal } from '../../ConnectKit';
+import { useModal } from '../../../hooks/useModal';
 
 type ButtonProps = {
   showSignOutButton?: boolean;

--- a/packages/connectkit/src/hooks/useModal.ts
+++ b/packages/connectkit/src/hooks/useModal.ts
@@ -1,0 +1,84 @@
+import { useAccount } from 'wagmi';
+import { routes, useContext } from '../components/ConnectKit';
+
+type ModalRoutes = typeof routes[keyof typeof routes];
+
+const safeRoutes: {
+  connected: ModalRoutes[];
+  disconnected: ModalRoutes[];
+} = {
+  disconnected: [
+    routes.CONNECTORS,
+    routes.ABOUT,
+    routes.ONBOARDING,
+    routes.MOBILECONNECTORS,
+    routes.ONBOARDING,
+  ],
+  connected: [routes.PROFILE, routes.SWITCHNETWORKS, routes.SIGNINWITHETHEREUM],
+};
+const allRoutes: ModalRoutes[] = [
+  ...safeRoutes.connected,
+  ...safeRoutes.disconnected,
+];
+
+type ValidRoutes = ModalRoutes;
+
+export const useModal = () => {
+  const context = useContext();
+  const { isConnected } = useAccount();
+
+  const close = () => {
+    context.setOpen(false);
+  };
+  const open = () => {
+    context.setOpen(true);
+  };
+
+  const gotoAndOpen = (route: ValidRoutes) => {
+    let validRoute: ValidRoutes = route;
+
+    if (!allRoutes.includes(route)) {
+      validRoute = isConnected ? routes.PROFILE : routes.CONNECTORS;
+      console.log(
+        `Route ${route} is not a valid route, navigating to ${validRoute} instead.`
+      );
+    } else {
+      if (isConnected) {
+        if (!safeRoutes.connected.includes(route)) {
+          validRoute = routes.PROFILE;
+          console.log(
+            `Route ${route} is not a valid route when connected, navigating to ${validRoute} instead.`
+          );
+        }
+      } else {
+        if (!safeRoutes.disconnected.includes(route)) {
+          validRoute = routes.CONNECTORS;
+          console.log(
+            `Route ${route} is not a valid route when disconnected, navigating to ${validRoute} instead.`
+          );
+        }
+      }
+    }
+
+    context.setRoute(validRoute);
+    open();
+  };
+
+  return {
+    open: context.open,
+    setOpen: (show: boolean) => {
+      if (show) {
+        gotoAndOpen(isConnected ? routes.PROFILE : routes.CONNECTORS);
+      } else {
+        close();
+      }
+    },
+    // Disconnected Routes
+    openAbout: () => gotoAndOpen(routes.ABOUT),
+    openOnboarding: () => gotoAndOpen(routes.ONBOARDING),
+    // Connected Routes
+    openProfile: () => gotoAndOpen(routes.PROFILE),
+    openSwitchNetworks: () => gotoAndOpen(routes.SWITCHNETWORKS),
+    openSignInWithEthereum: () => gotoAndOpen(routes.SIGNINWITHETHEREUM),
+  };
+};

--- a/packages/connectkit/src/hooks/useModal.ts
+++ b/packages/connectkit/src/hooks/useModal.ts
@@ -1,5 +1,6 @@
 import { useAccount } from 'wagmi';
 import { routes, useContext } from '../components/ConnectKit';
+import { useSIWE } from '../siwe';
 
 type ModalRoutes = typeof routes[keyof typeof routes];
 
@@ -26,6 +27,7 @@ type ValidRoutes = ModalRoutes;
 export const useModal = () => {
   const context = useContext();
   const { isConnected } = useAccount();
+  const { signIn } = useSIWE();
 
   const close = () => {
     context.setOpen(false);
@@ -79,6 +81,9 @@ export const useModal = () => {
     // Connected Routes
     openProfile: () => gotoAndOpen(routes.PROFILE),
     openSwitchNetworks: () => gotoAndOpen(routes.SWITCHNETWORKS),
-    openSignInWithEthereum: () => gotoAndOpen(routes.SIGNINWITHETHEREUM),
+    openSIWE: (triggerSIWE?: boolean) => {
+      gotoAndOpen(routes.SIGNINWITHETHEREUM);
+      if (triggerSIWE) signIn();
+    },
   };
 };

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -1,7 +1,7 @@
 export * as Types from './types';
 export { default as getDefaultClient, getGlobalChains } from './defaultClient';
 
-export { useModal } from './components/ConnectKit';
+export { useModal } from './hooks/useModal';
 export { SIWEProvider, useSIWE, SIWEConfig, SIWESession } from './siwe';
 
 export { ConnectKitProvider } from './components/ConnectKit';

--- a/packages/connectkit/src/siwe/useSIWE.ts
+++ b/packages/connectkit/src/siwe/useSIWE.ts
@@ -64,9 +64,11 @@ export const useSIWE = ({ onSignIn, onSignOut }: UseSIWEConfig = {}):
 
   const reset = () => resetStatus();
 
+  const isSignedIn = !!address;
+
   return {
-    isSignedIn: !!address,
-    data: !!address
+    isSignedIn,
+    data: isSignedIn
       ? {
           address: address as string,
           chainId: chainId as number,
@@ -80,12 +82,16 @@ export const useSIWE = ({ onSignIn, onSignOut }: UseSIWEConfig = {}):
     isSuccess,
     isReady,
     signIn: async () => {
-      const data = await signIn();
-      if (data) onSignIn?.(data);
+      if (!isSignedIn) {
+        const data = await signIn();
+        if (data) onSignIn?.(data);
+      }
     },
     signOut: async () => {
-      await signOut();
-      onSignOut?.();
+      if (isSignedIn) {
+        await signOut();
+        onSignOut?.();
+      }
     },
     reset,
   };


### PR DESCRIPTION
Adds functions to `useModal` hook to open direct to pages
Will fallback to default routes when opening to a route that is not allowed (e.g when no wallet is connected you can't navigate to the profile page)

* https://github.com/family/connectkit/discussions/146