### PR TITLE
SIWE route configurations

### DIFF
--- a/packages/connectkit-next-siwe/src/configureSIWE.tsx
+++ b/packages/connectkit-next-siwe/src/configureSIWE.tsx
@@ -81,7 +81,7 @@ const logoutRoute = async (
   req: NextApiRequest,
   res: NextApiResponse<void>,
   sessionConfig: IronSessionOptions,
-  afterCallback: RouteHandlerOptions['afterLogout']
+  afterCallback?: RouteHandlerOptions['afterLogout']
 ) => {
   switch (req.method) {
     case 'GET':
@@ -102,7 +102,7 @@ const nonceRoute = async (
   req: NextApiRequest,
   res: NextApiResponse<string>,
   sessionConfig: IronSessionOptions,
-  afterCallback: RouteHandlerOptions['afterNonce']
+  afterCallback?: RouteHandlerOptions['afterNonce']
 ) => {
   switch (req.method) {
     case 'GET':
@@ -126,7 +126,7 @@ const sessionRoute = async (
   req: NextApiRequest,
   res: NextApiResponse<{ address?: string; chainId?: number }>,
   sessionConfig: IronSessionOptions,
-  afterCallback: RouteHandlerOptions['afterSession']
+  afterCallback?: RouteHandlerOptions['afterSession']
 ) => {
   switch (req.method) {
     case 'GET':
@@ -147,7 +147,7 @@ const verifyRoute = async (
   req: NextApiRequest,
   res: NextApiResponse<void>,
   sessionConfig: IronSessionOptions,
-  afterCallback: RouteHandlerOptions['afterVerify']
+  afterCallback?: RouteHandlerOptions['afterVerify']
 ) => {
   switch (req.method) {
     case 'POST':

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -8,8 +8,6 @@ export type { SIWESession, SIWEConfig } from './siwe';
 export {
   ConnectKitProvider,
   Context,
-  useContext,
-  routes,
 } from './components/ConnectKit';
 export { ConnectKitButton } from './components/ConnectButton';
 export { default as SIWEButton } from './components/Standard/SIWE';

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -5,7 +5,12 @@ export { useModal } from './hooks/useModal';
 export { SIWEProvider, useSIWE } from './siwe';
 export type { SIWESession, SIWEConfig } from './siwe';
 
-export { ConnectKitProvider, Context } from './components/ConnectKit';
+export {
+  ConnectKitProvider,
+  Context,
+  useContext,
+  routes,
+} from './components/ConnectKit';
 export { ConnectKitButton } from './components/ConnectButton';
 export { default as SIWEButton } from './components/Standard/SIWE';
 


### PR DESCRIPTION
gm sers!
We're big fans of ConnectKit here at Metadrop, but we've ran into a few limitations which this PR is addressing:

1. We want to be able to perform server-side actions as part of the SIWE endpoints (similar to how [Auth0](https://github.com/auth0/nextjs-auth0) does it in their `handleAuth` handler), instead of requiring separate API calls post-SIWE for things like user management
2. It's very useful to have access to the modal context for things like navigation (i.e. presenting the sign in state immediately if wallet is already connected, instead of requiring the user to click "Connect" again to get to the SIWE screen)

Plz approve and merge thank you 🙏🏻