### PR TITLE
Add onShow and onHide callbacks to ConnectKitButton.Custom

### DIFF
--- a/packages/connectkit/src/components/ConnectButton/index.tsx
+++ b/packages/connectkit/src/components/ConnectButton/index.tsx
@@ -99,6 +99,8 @@ const textVariants: Variants = {
 type Hash = `0x${string}`;
 
 type ConnectButtonRendererProps = {
+  onShow?: () => void;
+  onHide?: () => void;
   children?: (renderProps: {
     show?: () => void;
     hide?: () => void;
@@ -115,6 +117,8 @@ type ConnectButtonRendererProps = {
 };
 
 const ConnectButtonRenderer: React.FC<ConnectButtonRendererProps> = ({
+  onShow,
+  onHide,
   children,
 }) => {
   const isMounted = useIsMounted();
@@ -130,10 +134,12 @@ const ConnectButtonRenderer: React.FC<ConnectButtonRendererProps> = ({
 
   function hide() {
     setOpen(false);
+    onHide?.();
   }
 
   function show() {
     setOpen(true);
+    onShow?.();
     context.setRoute(isConnected ? routes.PROFILE : routes.CONNECTORS);
   }
 


### PR DESCRIPTION
This PR adds two callbacks for `ConnectKitButton.Custom`: `onShow` and `onHide`.

These will be called as the user interacts with their custom ConnectKit button and the ConnectKit modal.

The motivation behind this PR was to provide a way for the external non-ConnectKit UI to update upon closing the modal, either by `esc` or the exit button in the modal. Right now there's currently no way to detect when the modal is closed.