### PR TITLE
Adding Rabby's open-sourced relay service after WalletConnect v1.0 relay servers' shutdown

### DIFF
--- a/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
+++ b/packages/connectkit/src/components/Common/CustomQRCode/index.tsx
@@ -62,7 +62,7 @@ function CustomQRCode({
               <QRCode
                 uri={value}
                 size={288}
-                ecl="M"
+                ecl="H"
                 clearArea={!!(imagePosition === 'center' && image)}
               />
             </motion.div>

--- a/packages/connectkit/src/defaultConfig.ts
+++ b/packages/connectkit/src/defaultConfig.ts
@@ -125,6 +125,7 @@ const getDefaultConnectors = ({
           chains,
           options: {
             qrcode: false,
+            bridge: 'https://derelay.rabby.io',
           },
         }),
     new InjectedConnector({

--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -30,6 +30,7 @@ export function useWalletConnectModal() {
           connector = new WalletConnectLegacyConnector({
             ...clientConnector,
             options: {
+              bridge: 'https://derelay.rabby.io',
               ...clientConnector.options,
               qrcode: true,
             },


### PR DESCRIPTION
## Issue

WalletConnect v1.0 relay server is expected to be offline on 28 June, 2023. To ensure uninterrupted usage and connectivity following the official v1.0 server shutdown, we are proposing the integration of [Rabby](https://github.com/RabbyHub/)'s open-sourced relay service. This relay service, maintained by Rabby, will guarantee continued connection between Dapps and Wallets using WalletConnect for users.

## Solution

We have included Rabby's self-host relay(https://derelay.rabby.io/) address in the web3 Wallet Connect kit, ensuring that users can connect to Dapp using WalletConnect. This address will become effective once the official relay server shuts down.

## Testing plan

We have thoroughly tested the solution in both the testing environment and the live online environment. Based on our testing, we are confident that the solution will enable users to connect to Dapps using WalletConnect without any issues.