### PR TITLE
fix: w3m overrides

### DIFF
--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -17,7 +17,7 @@ export function useWalletConnectModal() {
     open: async () => {
       //add modal styling because wagmi does not let you add styling to the modal
       const w3mcss = document.createElement('style');
-      w3mcss.innerHTML = `w3m-modal{ --w3m-z-index: 2147483647; }`;
+      w3mcss.innerHTML = `w3m-modal{ --wcm-z-index: 2147483647; --w3m-z-index:2147483647; }`;
       document.head.appendChild(w3mcss);
 
       const clientConnector: Connector<any, any> | undefined = connectors.find(


### PR DESCRIPTION
updates web3modal z-index variable name, and keeps previous versions for those who are on older versions of wagmi

opting to not use the [walletconnect `themeVariables`](https://docs.walletconnect.com/2.0/web/walletConnectModal/modal/options#themevariables-optional) to set the z-index because if wagmi version isn't correct this could throw errors. we will move to this at a later date.