### PR TITLE
fix: check if injected connector exists

### DIFF
--- a/packages/connectkit/src/hooks/connectors/useInjectedWallet.tsx
+++ b/packages/connectkit/src/hooks/connectors/useInjectedWallet.tsx
@@ -7,6 +7,8 @@ export const useInjectedWallet = () => {
   const connector = useInjectedConnector();
 
   const getInjectedNames = () => {
+    if (!connector) return [];
+
     let names = connector.name.split(/[(),]+/);
     names.shift(); // remove "Injected" from array
     names = names


### PR DESCRIPTION
adds check for when trying to get `name` when injected connector isn't in the configs.

fixes: #294 