### PR TITLE
Fix: UI hidden on rejected network change

### DIFF
--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -146,69 +146,71 @@ const ChainSelectList = ({
                   </ChainLogoContainer>
                   {ch.name}
                 </span>
-                <ChainButtonStatus>
-                  <AnimatePresence initial={false} exitBeforeEnter>
-                    {ch.id === chain?.id && (
-                      <motion.span
-                        key={'connectedText'}
-                        style={{
-                          color:
-                            'var(--ck-dropdown-active-color, var(--ck-focus-color))',
-                          display: 'block',
-                          position: 'relative',
-                        }}
-                        initial={{ opacity: 0, x: -4 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{
-                          opacity: 0,
-                          x: 4,
-                          transition: { duration: 0.1, delay: 0 },
-                        }}
-                        transition={{
-                          ease: [0.76, 0, 0.24, 1],
-                          duration: 0.3,
-                          delay: 0.2,
-                        }}
-                      >
-                        {locales.connected}
-                      </motion.span>
-                    )}
-                    {isLoading && pendingChainId === ch.id && (
-                      <motion.span
-                        key={'approveText'}
-                        style={{
-                          color: 'var(--ck-dropdown-pending-color, inherit)',
-                          display: 'block',
-                          position: 'relative',
-                        }}
-                        initial={{
-                          opacity: 0,
-                          x: -4,
-                        }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: 4 }}
-                        transition={{
-                          ease: [0.76, 0, 0.24, 1],
-                          duration: 0.3,
-                          delay: 0.1,
-                        }}
-                      >
+                {variant !== 'secondary' && (
+                  <ChainButtonStatus>
+                    <AnimatePresence initial={false} exitBeforeEnter>
+                      {ch.id === chain?.id && (
                         <motion.span
-                          animate={
-                            // UI fix for Coinbase Wallet on mobile does not remove isLoading on rejection event
-                            mobile &&
-                            isCoinbaseWalletConnector(connector?.id) && {
-                              opacity: [1, 0],
-                              transition: { delay: 4, duration: 4 },
-                            }
-                          }
+                          key={'connectedText'}
+                          style={{
+                            color:
+                              'var(--ck-dropdown-active-color, var(--ck-focus-color))',
+                            display: 'block',
+                            position: 'relative',
+                          }}
+                          initial={{ opacity: 0, x: -4 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          exit={{
+                            opacity: 0,
+                            x: 4,
+                            transition: { duration: 0.1, delay: 0 },
+                          }}
+                          transition={{
+                            ease: [0.76, 0, 0.24, 1],
+                            duration: 0.3,
+                            delay: 0.2,
+                          }}
                         >
-                          {locales.approveInWallet}
+                          {locales.connected}
                         </motion.span>
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
-                </ChainButtonStatus>
+                      )}
+                      {isLoading && pendingChainId === ch.id && (
+                        <motion.span
+                          key={'approveText'}
+                          style={{
+                            color: 'var(--ck-dropdown-pending-color, inherit)',
+                            display: 'block',
+                            position: 'relative',
+                          }}
+                          initial={{
+                            opacity: 0,
+                            x: -4,
+                          }}
+                          animate={{ opacity: 1, x: 0 }}
+                          exit={{ opacity: 0, x: 4 }}
+                          transition={{
+                            ease: [0.76, 0, 0.24, 1],
+                            duration: 0.3,
+                            delay: 0.1,
+                          }}
+                        >
+                          <motion.span
+                            animate={
+                              // UI fix for Coinbase Wallet on mobile does not remove isLoading on rejection event
+                              mobile &&
+                              isCoinbaseWalletConnector(connector?.id) && {
+                                opacity: [1, 0],
+                                transition: { delay: 4, duration: 4 },
+                              }
+                            }
+                          >
+                            {locales.approveInWallet}
+                          </motion.span>
+                        </motion.span>
+                      )}
+                    </AnimatePresence>
+                  </ChainButtonStatus>
+                )}
                 {variant === 'secondary' ? (
                   <ChainButtonBg
                     initial={false}

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -59,13 +59,14 @@ const ChainSelectList = ({
 }) => {
   const { connector } = useAccount();
   const { chain, chains } = useNetwork();
-  const { status, isLoading, pendingChainId, switchNetwork } =
+  const { isLoading, pendingChainId, switchNetwork, error } =
     useSwitchNetwork();
 
   const locales = useLocales({});
   const mobile = isMobile();
 
-  const disabled = status === 'error' || !switchNetwork;
+  const isError = error?.['code'] === 4902; // Wallet cannot switch networks
+  const disabled = isError || !switchNetwork;
 
   const handleSwitchNetwork = (chainId: number) => {
     if (switchNetwork) {
@@ -238,19 +239,16 @@ const ChainSelectList = ({
         </ChainButtons>
       </ChainButtonContainer>
       <AnimatePresence>
-        {disabled && (
+        {isError && (
           <motion.div
-            style={{
-              overflow: 'hidden',
-            }}
-            initial={{ height: 0 }}
-            animate={{ height: 'auto' }}
-            exit={{ height: 0 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{
               ease: [0.76, 0, 0.24, 1],
               duration: 0.3,
             }}
-            //onUpdate={triggerResize}
+            onAnimationStart={triggerResize}
             onAnimationComplete={triggerResize}
           >
             <div style={{ paddingTop: 10, paddingBottom: 8 }}>

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -60,13 +60,12 @@ const ChainSelectList = ({
 }) => {
   const { connector } = useAccount();
   const { chain, chains } = useNetwork();
-  const { status, isLoading, pendingChainId, switchNetwork } =
-    useSwitchNetwork();
+  const { isLoading, pendingChainId, switchNetwork } = useSwitchNetwork();
 
   const locales = useLocales({});
   const mobile = isMobile();
 
-  const disabled = status === 'error' || !switchNetwork;
+  const disabled = !switchNetwork;
 
   const handleSwitchNetwork = (chainId: number) => {
     if (switchNetwork) {

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -60,12 +60,13 @@ const ChainSelectList = ({
 }) => {
   const { connector } = useAccount();
   const { chain, chains } = useNetwork();
-  const { isLoading, pendingChainId, switchNetwork } = useSwitchNetwork();
+  const { status, isLoading, pendingChainId, switchNetwork } =
+    useSwitchNetwork();
 
   const locales = useLocales({});
   const mobile = isMobile();
 
-  const disabled = !switchNetwork;
+  const disabled = status === 'error' || !switchNetwork;
 
   const handleSwitchNetwork = (chainId: number) => {
     if (switchNetwork) {

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi';
 import supportedChains from '../../../constants/supportedChains';
 
@@ -21,6 +19,7 @@ import { isCoinbaseWalletConnector, isMobile } from '../../../utils';
 
 import ChainIcons from '../../../assets/chains';
 import useLocales from '../../../hooks/useLocales';
+import { useContext } from '../../ConnectKit';
 
 const Spinner = (
   <svg
@@ -73,6 +72,8 @@ const ChainSelectList = ({
       switchNetwork(chainId);
     }
   };
+
+  const { triggerResize } = useContext();
 
   return (
     <SwitchNetworksContainer style={{ marginBottom: switchNetwork ? -8 : 0 }}>
@@ -249,6 +250,8 @@ const ChainSelectList = ({
               ease: [0.76, 0, 0.24, 1],
               duration: 0.3,
             }}
+            //onUpdate={triggerResize}
+            onAnimationComplete={triggerResize}
           >
             <div style={{ paddingTop: 10, paddingBottom: 8 }}>
               <Alert>

--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -303,7 +303,14 @@ const Modal: React.FC<ModalProps> = ({
   const ref = useRef<any>(null);
   useEffect(() => {
     if (ref.current) updateBounds(ref.current);
-  }, [chain, switchNetwork, mobile, isSignedIn, context.options]);
+  }, [
+    chain,
+    switchNetwork,
+    mobile,
+    isSignedIn,
+    context.options,
+    context.resize,
+  ]);
 
   useEffect(() => {
     if (!mounted) {

--- a/packages/connectkit/src/components/ConnectKit.tsx
+++ b/packages/connectkit/src/components/ConnectKit.tsx
@@ -65,6 +65,8 @@ type ContextValue = {
   debugMode?: boolean;
   log: (...props: any) => void;
   displayError: (message: string | React.ReactNode | null, code?: any) => void;
+  resize: number;
+  triggerResize: () => void;
 } & useConnectCallbackProps;
 
 export const Context = createContext<ContextValue | null>(null);
@@ -177,6 +179,8 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
   const [route, setRoute] = useState<string>(routes.CONNECTORS);
   const [errorMessage, setErrorMessage] = useState<Error>('');
 
+  const [resize, onResize] = useState<number>(0);
+
   // Include Google Font that is needed for a themes
   if (opts.embedGoogleFonts) useThemeFont(theme);
 
@@ -232,6 +236,8 @@ export const ConnectKitProvider: React.FC<ConnectKitProviderProps> = ({
       if (code) console.table(code);
       console.log('---------/CONNECTKIT DEBUG---------');
     },
+    resize,
+    triggerResize: () => onResize((prev) => prev + 1),
   };
 
   return createElement(


### PR DESCRIPTION
* adds resize trigger
* hides "approve in wallet" text on secondary switchnetwork view
* shows error when `switchNetwork` throws error code `4902` instead of on any error

fixes: #277 #78

