### PR TITLE
add zerion extension support

### DIFF
--- a/packages/connectkit/src/utils/wallets.ts
+++ b/packages/connectkit/src/utils/wallets.ts
@@ -129,3 +129,13 @@ export const isRainbow = () => {
       ethereum?.providers.find((provider) => provider.isRainbow))
   );
 };
+
+export const isZerion = () => {
+  if (typeof window === 'undefined') return false;
+  const { ethereum } = window;
+  return !!(
+    ethereum?.isZerion ||
+    (ethereum?.providers &&
+      ethereum?.providers.find((provider) => provider.isZerion))
+  );
+};

--- a/packages/connectkit/src/wallets/connectors/zerion.tsx
+++ b/packages/connectkit/src/wallets/connectors/zerion.tsx
@@ -2,8 +2,11 @@ import { WalletProps } from './../wallet';
 
 import { isAndroid } from '../../utils';
 import Logos from './../../assets/logos';
+import { isZerion } from '../../utils/wallets';
 
 export const zerion = (): WalletProps => {
+  const isInstalled = isZerion();
+
   return {
     id: 'zerion',
     name: 'Zerion',
@@ -24,5 +27,6 @@ export const zerion = (): WalletProps => {
         ? uri
         : `https://app.zerion.io/wc?uri=${encodeURIComponent(uri)}`;
     },
+    installed: isInstalled,
   };
 };


### PR DESCRIPTION
- Fixes support for Zerion extension by following the `isInstalled` pattern used by other wallets

**Before**
<img width="361" alt="Screenshot 2023-10-13 at 12 20 21 PM" src="https://github.com/family/connectkit/assets/103902448/2e7938b7-41fb-4196-847e-fcde979c8d4e">

**After**
<img width="364" alt="Screenshot 2023-10-13 at 12 20 56 PM" src="https://github.com/family/connectkit/assets/103902448/9ecfaf91-f105-4836-8912-207c6cb788f2">
