### PR TITLE
Fix: Hide siwe tooltip when hiteTooltips is enabled

### DIFF
--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -509,7 +509,7 @@ const Modal: React.FC<ModalProps> = ({
                   ) : context.route === routes.PROFILE &&
                     context.signInWithEthereum ? (
                     <>
-                      {!isSignedIn && (
+                      {!isSignedIn && !context.options?.hideTooltips && (
                         <motion.div
                           style={{
                             position: 'absolute',


### PR DESCRIPTION
I don't know if you'd like a demonstration of the tweak, but it's a super minimal bugfix. I mentioned this in #304 and just remembered about it, sorry for the delay.
