### PR TITLE
update: use wagmi storage instead of connectkit storage

### DIFF
--- a/packages/connectkit/src/hooks/useConnect.tsx
+++ b/packages/connectkit/src/hooks/useConnect.tsx
@@ -15,8 +15,6 @@ import { useLastConnector } from './useLastConnector';
 export function useConnect({ ...props }: UseConnectParameters = {}) {
   const context = useContext();
 
-  const { updateLastConnectorId } = useLastConnector();
-
   const { connect, connectAsync, connectors, ...rest } = wagmiUseConnect({
     ...props,
     mutation: {
@@ -29,11 +27,6 @@ export function useConnect({ ...props }: UseConnectParameters = {}) {
         } else {
           context.log(`Could not connect.`, err);
         }
-      },
-      onSuccess(data: any) {
-        updateLastConnectorId(
-          `${data?.connector?.id}-${data?.connector?.name}` ?? ''
-        );
       },
     },
   });

--- a/packages/connectkit/src/hooks/useLastConnector.ts
+++ b/packages/connectkit/src/hooks/useLastConnector.ts
@@ -1,25 +1,24 @@
-import { useLocalStorage } from './useLocalStorage';
+import { useEffect, useState } from 'react';
+import { useConfig } from 'wagmi';
 
 export const useLastConnector = () => {
-  const {
-    data: lastConnectorId,
-    add,
-    update,
-    clear,
-  } = useLocalStorage('connectKit.lastConnectorId');
+  const { storage } = useConfig();
+  const [lastConnectorId, setLastConnectorId] = useState<string | null>(null);
 
-  const updateLastConnectorId = (id: string) => {
-    if (lastConnectorId) {
-      if (lastConnectorId === id) return;
-      clear();
-      update(id);
-    } else {
-      add(id);
-    }
+  useEffect(() => {
+    const init = async () => {
+      const id = await storage?.getItem('recentConnectorId');
+      setLastConnectorId(id ?? '');
+    };
+    init();
+  }, []);
+
+  const update = (id: string) => {
+    storage?.setItem('recentConnectorId', id);
   };
 
   return {
     lastConnectorId,
-    updateLastConnectorId,
+    updateLastConnectorId: update,
   };
 };


### PR DESCRIPTION
remove our localstorage solution and opting for wagmi's storage as this stores the same information