### PR TITLE
Fix isChainSupported in BalanceButton

### DIFF
--- a/packages/connectkit/src/components/BalanceButton/index.tsx
+++ b/packages/connectkit/src/components/BalanceButton/index.tsx
@@ -53,7 +53,7 @@ export const Balance: React.FC<BalanceProps> = ({ hideIcon, hideSymbol }) => {
 
   const { address, chain } = useAccount();
   const chains = useChains();
-  const unsupported = useChainIsSupported(chain?.id);
+  const isChainSupported = useChainIsSupported(chain?.id);
 
   const queryClient = useQueryClient();
   const { data: blockNumber } = useBlockNumber({ watch: true });
@@ -114,7 +114,7 @@ export const Balance: React.FC<BalanceProps> = ({ hideIcon, hideSymbol }) => {
                 </PulseContainer>
               </span>
             </Container>
-          ) : unsupported ? (
+          ) : !isChainSupported ? (
             <Container>
               {!hideIcon && <Chain id={chain?.id} />}
               <span style={{ minWidth: 32 }}>???</span>

--- a/packages/connectkit/src/components/BalanceButton/index.tsx
+++ b/packages/connectkit/src/components/BalanceButton/index.tsx
@@ -105,7 +105,7 @@ export const Balance: React.FC<BalanceProps> = ({ hideIcon, hideSymbol }) => {
         >
           {!address || !isMounted || balance?.formatted === undefined ? (
             <Container>
-              {!hideIcon && <Chain />}
+              {!hideIcon && <Chain id={chain?.id} />}
               <span style={{ minWidth: 32 }}>
                 <PulseContainer>
                   <span style={{ animationDelay: '0ms' }} />

--- a/packages/connectkit/src/hooks/useChainIsSupported.ts
+++ b/packages/connectkit/src/hooks/useChainIsSupported.ts
@@ -1,7 +1,7 @@
 import { useConfig } from 'wagmi';
 
 export function useChainIsSupported(chainId?: number): boolean | null {
-  if (!chainId) return false;
   const { chains } = useConfig();
+  if (!chainId) return false;
   return chains.some((x) => x.id === chainId);
 }


### PR DESCRIPTION
# Found issue:
- When showBalance=true on ConnectKitButton and when chain is supported, balance is not properly displayed.
- Bad loading on Chain component logo at initialization.
- Invalid useConfig hook order inside useChainIsSupported hook.

![balance-error](https://github.com/family/connectkit/assets/38438271/d2f57eca-fddb-4e00-be84-430cb6a54907)

# Proposed solution:
- Rename "unsupported" to "isChainSupported" to improve consistency with other parts of the codebase.
- Inverse boolean condition to fix the bug on balance.
- Proper initial logo loading by adding id prop to Chain component.
- Move useConfig hook at the top of useChainIsSupported hook to avoid "change in the order of Hooks" on early return.