### PR TITLE
Remove initialData in nonce and session

### DIFF
--- a/packages/connectkit/src/siwe/SIWEProvider.tsx
+++ b/packages/connectkit/src/siwe/SIWEProvider.tsx
@@ -48,14 +48,12 @@ export const SIWEProvider = ({
   const nonce = useQuery({
     queryKey: ['ckSiweNonce'],
     queryFn: () => siweConfig.getNonce(),
-    initialData: null,
     refetchInterval: nonceRefetchInterval,
   });
 
   const session = useQuery({
     queryKey: ['ckSiweSession'],
     queryFn: () => siweConfig.getSession(),
-    initialData: null,
     refetchInterval: sessionRefetchInterval,
   });
 


### PR DESCRIPTION
It appears that in @tanstack/react-query v5 and up the query will not be fetched on mount if `initialData` is anything other than `undefined`. This means that the `ckSiweNonce` and `ckSiweSession` queries don't fire for the first time until their respective intervals have elapsed.

This commit removes the `initialData` for both of these queries in order to restore previous functionality.

Versions used to reproduce issue:
`"@tanstack/react-query": "5.18.1"` & `"connectkit": "1.7.1"`

