### PR TITLE
Fix ENS resolution if mainnet not supported

### DIFF
--- a/packages/connectkit/src/components/Common/Avatar/index.tsx
+++ b/packages/connectkit/src/components/Common/Avatar/index.tsx
@@ -7,6 +7,7 @@ import { normalize } from 'viem/ens';
 import { ResetContainer } from '../../../styles';
 import { useContext } from '../../ConnectKit';
 import useIsMounted from '../../../hooks/useIsMounted';
+import { useEnsFallbackConfig } from '../../../hooks/useEnsFallbackConfig';
 
 type Hash = `0x${string}`;
 
@@ -30,17 +31,21 @@ const Avatar: React.FC<{
   const imageRef = useRef<any>(null);
   const [loaded, setLoaded] = useState(true);
 
+  const ensFallbackConfig = useEnsFallbackConfig();
   const { data: ensAddress } = useEnsAddress({
     chainId: 1,
     name: name,
+    config: ensFallbackConfig,
   });
   const { data: ensName } = useEnsName({
     chainId: 1,
     address: address ?? ensAddress ?? undefined,
+    config: ensFallbackConfig,
   });
   const { data: ensAvatar } = useEnsAvatar({
     chainId: 1,
     name: normalize(ensName ?? ''),
+    config: ensFallbackConfig,
   });
 
   const ens = {

--- a/packages/connectkit/src/components/ConnectButton/index.tsx
+++ b/packages/connectkit/src/components/ConnectButton/index.tsx
@@ -22,6 +22,7 @@ import { useSIWE } from '../../siwe';
 import useLocales from '../../hooks/useLocales';
 import { Chain } from 'viem';
 import { useChainIsSupported } from '../../hooks/useChainIsSupported';
+import { useEnsFallbackConfig } from '../../hooks/useEnsFallbackConfig';
 
 const contentVariants: Variants = {
   initial: {
@@ -126,9 +127,11 @@ const ConnectButtonRenderer: React.FC<ConnectButtonRendererProps> = ({
   const { address, isConnected, chain } = useAccount();
   const isChainSupported = useChainIsSupported(chain?.id);
 
+  const ensFallbackConfig = useEnsFallbackConfig();
   const { data: ensName } = useEnsName({
     chainId: 1,
     address: address,
+    config: ensFallbackConfig,
   });
 
   function hide() {
@@ -178,9 +181,11 @@ function ConnectKitButtonInner({
   const { address, chain } = useAccount();
   const isChainSupported = useChainIsSupported(chain?.id);
 
+  const ensFallbackConfig = useEnsFallbackConfig();
   const { data: ensName } = useEnsName({
     chainId: 1,
     address: address,
+    config: ensFallbackConfig,
   });
   const defaultLabel = locales.connectWallet;
 

--- a/packages/connectkit/src/components/Pages/Profile/index.tsx
+++ b/packages/connectkit/src/components/Pages/Profile/index.tsx
@@ -38,6 +38,7 @@ import CopyToClipboard from '../../Common/CopyToClipboard';
 import { AnimatePresence } from 'framer-motion';
 import { useThemeContext } from '../../ConnectKitThemeProvider/ConnectKitThemeProvider';
 import useLocales from '../../../hooks/useLocales';
+import { useEnsFallbackConfig } from '../../../hooks/useEnsFallbackConfig';
 
 const Profile: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
   const context = useContext();
@@ -49,9 +50,11 @@ const Profile: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
   const { disconnect } = useDisconnect();
 
   const { address, isConnected, connector, chain } = useAccount();
+  const ensFallbackConfig = useEnsFallbackConfig();
   const { data: ensName } = useEnsName({
     chainId: 1,
     address: address,
+    config: ensFallbackConfig,
   });
   const { data: balance } = useBalance({
     address,

--- a/packages/connectkit/src/hooks/useEnsFallbackConfig.ts
+++ b/packages/connectkit/src/hooks/useEnsFallbackConfig.ts
@@ -1,0 +1,15 @@
+import type { Config } from '@wagmi/core';
+import { http, createConfig } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import { useChainIsSupported } from '../hooks/useChainIsSupported';
+
+const ensFallbackConfig = createConfig({
+  chains: [mainnet],
+  transports: {
+    [mainnet.id]: http(),
+  },
+});
+
+export function useEnsFallbackConfig(): Config | undefined {
+  return !useChainIsSupported(1) ? ensFallbackConfig : undefined;
+}


### PR DESCRIPTION
# Found issue:
- [Check issue 350](https://github.com/family/connectkit/issues/350) reported by @SonOfMosiah

# Proposed solution:
- Add useEnsFallbackConfig hook to easily guarantee mainnet access to all ENS-related hooks, regardless of the chains supported by the dapp.