### PR TITLE
fix: adjust Phantom wallet detection

### DIFF
--- a/packages/connectkit/src/utils/wallets.ts
+++ b/packages/connectkit/src/utils/wallets.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     trustWallet: any;
     trustwallet: any;
+    phantom: any;
   }
 }
 
@@ -22,7 +23,10 @@ export const isBrave = () => isWalletInstalled('BraveWallet');
 export const isTokenary = () => isWalletInstalled('Tokenary');
 export const isDawn = () => isWalletInstalled('Dawn');
 export const isFrame = () => isWalletInstalled('Frame');
-export const isPhantom = () => isWalletInstalled('Phantom');
+export const isPhantom = () => {
+  if (typeof window === 'undefined') return false;
+  return isWalletInstalled('Phantom') || window?.phantom?.ethereum?.isPhantom;
+};
 export const isInfinityWallet = () => isWalletInstalled('InfinityWallet');
 export const isRabby = () => isWalletInstalled('Rabby');
 export const isFrontier = () => isWalletInstalled('Frontier');


### PR DESCRIPTION
With the latest Phantom extension release the `isPhantom` property disappeared from the `ethereum` object. Instead it is on the `window.phantom.ethereum` object.

Looks like the changed occurred between the versions `24.1.0` and `24.2.0`