### PR TITLE
chore(query-keys): Export `SIWEProvider`'s two query keys, allowing package consumers to invalidate queries

### DIFF
--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -6,7 +6,12 @@ export { default as getDefaultConnectors } from './defaultConnectors';
 export { wallets } from './wallets';
 
 export { useModal } from './hooks/useModal';
-export { SIWEProvider, useSIWE } from './siwe';
+export {
+  SIWEProvider,
+  useSIWE,
+  SIWE_NONCE_QUERY_KEY,
+  SIWE_SESSION_QUERY_KEY,
+} from './siwe';
 export type { SIWESession, SIWEConfig } from './siwe';
 
 export { ConnectKitProvider, Context } from './components/ConnectKit';

--- a/packages/connectkit/src/siwe/SIWEProvider.tsx
+++ b/packages/connectkit/src/siwe/SIWEProvider.tsx
@@ -17,6 +17,9 @@ type Props = SIWEConfig & {
   onSignOut?: () => void;
 };
 
+export const SIWE_NONCE_QUERY_KEY = 'ckSiweNonce';
+export const SIWE_SESSION_QUERY_KEY = 'ckSiweSession';
+
 export const SIWEProvider = ({
   children,
   enabled = true,
@@ -46,13 +49,13 @@ export const SIWEProvider = ({
   }
 
   const nonce = useQuery({
-    queryKey: ['ckSiweNonce'],
+    queryKey: [SIWE_NONCE_QUERY_KEY],
     queryFn: () => siweConfig.getNonce(),
     refetchInterval: nonceRefetchInterval,
   });
 
   const session = useQuery({
-    queryKey: ['ckSiweSession'],
+    queryKey: [SIWE_SESSION_QUERY_KEY],
     queryFn: () => siweConfig.getSession(),
     refetchInterval: sessionRefetchInterval,
   });

--- a/packages/connectkit/src/siwe/index.ts
+++ b/packages/connectkit/src/siwe/index.ts
@@ -1,3 +1,7 @@
 export { useSIWE } from './useSIWE';
-export { SIWEProvider } from './SIWEProvider';
+export {
+  SIWEProvider,
+  SIWE_SESSION_QUERY_KEY,
+  SIWE_NONCE_QUERY_KEY,
+} from './SIWEProvider';
 export { SIWEContext, SIWEConfig, SIWESession } from './SIWEContext';


### PR DESCRIPTION
In order to refetch the SIWE session on account change, I need to imperatively trigger a refetch of the `session` query in [SIWEProvider.tsx](https://github.com/family/connectkit/blob/main/packages/connectkit/src/siwe/SIWEProvider.tsx#L54-L58).

This can be achieved without a const by simply targetting the query key of string "ckSiweSession" - however it is brittle and susceptible to breaking changes.

Exporting these query keys as constants allows package consumers to refetch/manipulate the queries as necessary.