### PR TITLE
Add ca_AD Language Support

### DIFF
--- a/examples/testbench/src/pages/index.tsx
+++ b/examples/testbench/src/pages/index.tsx
@@ -54,6 +54,7 @@ const modes: SelectProps[] = [
 ];
 const languages: SelectProps[] = [
   { label: 'English (US)', value: 'en-US' },
+  { label: 'Catalan', value: 'ca-AD' },
   { label: 'French', value: 'fr-FR' },
   { label: 'Spanish', value: 'es-ES' },
   { label: 'Japanese', value: 'ja-JP' },

--- a/packages/connectkit/src/localizations/index.tsx
+++ b/packages/connectkit/src/localizations/index.tsx
@@ -4,7 +4,8 @@ export type Languages =
   | 'fr-FR'
   | 'ja-JP'
   | 'pt-BR'
-  | 'zh-CN';
+  | 'zh-CN'
+  | 'ca-AD';
 
 import { default as enUS } from './locales/en-US';
 import { default as esES } from './locales/es-ES';
@@ -12,6 +13,7 @@ import { default as frFR } from './locales/fr-FR';
 import { default as jaJP } from './locales/ja-JP';
 import { default as ptBR } from './locales/pt-BR';
 import { default as zhCN } from './locales/zh-CN';
+import { default as caAD } from './locales/ca-AD';
 
 // TODO: tree-shaking
 export const getLocale = (lang: Languages) => {
@@ -26,6 +28,8 @@ export const getLocale = (lang: Languages) => {
       return ptBR;
     case 'zh-CN':
       return zhCN;
+    case 'ca-AD':
+      return caAD;
     default:
       return enUS;
   }

--- a/packages/connectkit/src/localizations/locales/ca-AD.ts
+++ b/packages/connectkit/src/localizations/locales/ca-AD.ts
@@ -1,0 +1,116 @@
+import { LocaleProps } from './';
+
+const caAD: LocaleProps = {
+  connectWallet: 'Connecta la cartera',
+    disconnect: 'Desconnectar',
+    connected: 'Connectat',
+    wrongNetwork: 'Xarxa incorrecta',
+    switchNetworks: 'Canvi de xarxa',
+    chainNetwork: 'Xarxa {{ CHAIN }}',
+    copyToClipboard: 'Copia al portapapers',
+    copyCode: 'Copia codi',
+    moreInformation: 'Més informació',
+    back: 'Enrere',
+    close: 'Tanca',
+    or: 'o',
+    more: 'Més',
+    tryAgain: 'Torna-ho a intentar',
+    tryAgainQuestion: 'Tornar a intentar-ho?',
+    dontHaveTheApp: "No tens l'aplicació?",
+    scanTheQRCode: 'Escaneja el codi QR',
+    useWalletConnectModal: 'Utilitza WalletConnect Modal',
+    useModal: 'Utilitza Modal',
+    installTheExtension: "Instal·la l'extensió",
+    getWalletName: 'Obté {{ CONNECTORNAME }}',
+    otherWallets: 'Altres carteres',
+    learnMore: 'Més informació',
+    getWallet: 'Obté una cartera',
+    approveInWallet: 'Aprova a la cartera',
+    confirmInWallet: 'Confirma a la cartera',
+    awaitingConfirmation: 'Esperant confirmació',
+    signIn: 'Inicia sessió',
+    signOut: 'Tanca sessió',
+    signedIn: 'Sessió iniciada',
+    signedOut: 'Sessió tancada',
+    walletNotConnected: 'Cartera no connectada',
+  
+    warnings_walletSwitchingUnsupported: `La teva cartera no permet canviar de xarxa des d'aquesta aplicació.`,
+    warnings_walletSwitchingUnsupportedResolve: `Prova a canviar de xarxa des de la teva cartera.`,
+    warnings_chainUnsupported: `Aquesta aplicació no és compatible amb la xarxa connectada actualment.`,
+    warnings_chainUnsupportedResolve: `Canvia o desconnecta per continuar.`,
+
+    onboardingScreen_heading: `Obté una cartera`,
+    onboardingScreen_h1: `Comença a explorar la Web3`,
+    onboardingScreen_p: `La teva cartera és el portal d'accés a tot el relacionat amb Ethereum, la tecnologia màgica que permet explorar la Web3.`,
+    onboardingScreen_ctaText: `Tria la teva primera cartera`,
+    onboardingScreen_ctaUrl: `https://ethereum.org/es/wallets/find-wallet/`,
+
+    aboutScreen_heading: `Sobre les carteres`,
+    aboutScreen_a_h1: `Per als teus actius digitals`,
+    aboutScreen_a_p: `Les carteres et permeten enviar, rebre, emmagatzemar i interactuar amb actius digitals com els NFT i altres tokens d'Ethereum.`,
+    aboutScreen_b_h1: `Una manera millor d'iniciar sessió`,
+    aboutScreen_b_p: `Amb les aplicacions modernes, pots utilitzar la teva cartera per iniciar sessió fàcilment, en lloc de haver de recordar una contrasenya.`,
+    aboutScreen_c_h1: `Explora el món de la Web3`,
+    aboutScreen_c_p: `La teva cartera és una eina essencial que et permet explorar i participar en el món en ràpida evolució de la Web3.`,
+    aboutScreen_ctaText: `Més informació`,
+    aboutScreen_ctaUrl: `https://ethereum.org/es/wallets/`,
+
+    connectorsScreen_heading: `Connecta una cartera`,
+    connectorsScreen_newcomer: `No tinc una cartera`,
+    connectorsScreen_h1: `Què és una cartera?`,
+    connectorsScreen_p: `Les carteres s'utilitzen per enviar, rebre i emmagatzemar actius digitals. Si connectes una cartera, podràs interactuar amb les aplicacions.`,
+
+    mobileConnectorsScreen_heading: `Tria una cartera`,
+
+    scanScreen_heading: `Escaneja amb el telèfon`,
+    scanScreen_heading_withConnector: `Escaneja amb {{ CONNECTORNAME }}`,
+    scanScreen_tooltip_walletConnect: `Obre una cartera compatible amb WalletConnect [WALLETCONNECTLOGO] per escanejar`,
+    scanScreen_tooltip_default: `Obre {{ CONNECTORNAME }} en el teu telèfon mòbil per escanejar`,
+
+    downloadAppScreen_heading: `Obté {{ CONNECTORNAME }}`,
+    downloadAppScreen_iosAndroid: `Escaneja amb la càmera del teu telèfon per descarregar-la en iOS o Android.`,
+    downloadAppScreen_ios: `Escaneja amb la càmera del teu telèfon per descarregar-la en iOS.`,
+    downloadAppScreen_android: `Escaneja amb la càmera del teu telèfon per descarregar-la en Android.`,
+
+    injectionScreen_unavailable_h1: `Navegador no compatible`,
+    injectionScreen_unavailable_p: `Per connectar la teva cartera de {{ CONNECTORSHORTNAME }}, instal·la l'extensió en {{ SUGGESTEDEXTENSIONBROWSER }}.`,
+
+    injectionScreen_install_h1: `Instal·la {{ CONNECTORNAME }}`,
+    injectionScreen_install_p: `Per connectar la teva cartera de {{ CONNECTORSHORTNAME }}, instal·la l'extensió del navegador.`,
+
+    injectionScreen_connecting_h1: `Sol·licitud de connexió`,
+    injectionScreen_connecting_p: `Obre l'extensió del navegador de {{ CONNECTORSHORTNAME }}  per connectar la teva cartera.`,
+
+    injectionScreen_connecting_injected_h1: `Sol·licitud de connexió`,
+    injectionScreen_connecting_injected_p: `Accepta la sol·licitud a través de la teva cartera per connectar-te a aquesta aplicació.`,
+
+    injectionScreen_connected_h1: `Ja connectada`,
+    injectionScreen_connected_p: `Ja pots tancar aquesta finestra emergent`,
+
+    injectionScreen_rejected_h1: `Sol·licitud cancel·lada`,
+    injectionScreen_rejected_p: `Has cancel·lat la sol·licitud. Fes clic a dalt per tornar-ho a intentar.`,
+
+    injectionScreen_failed_h1: `Error de connexió`,
+    injectionScreen_failed_p: `Ho sentim, hi ha hagut un problema. Intenta connectar-te de nou.`,
+
+    injectionScreen_notconnected_h1: `Inicia sessió en {{ CONNECTORNAME }}`,
+    injectionScreen_notconnected_p: `Per continuar, inicia sessió en la teva extensió de {{ CONNECTORNAME }}.`,
+
+    profileScreen_heading: 'Connectat',
+
+    switchNetworkScreen_heading: 'Canvi de xarxa',
+
+    signInWithEthereumScreen_tooltip: 'No has iniciat sessió en aquesta aplicació.\n**Inicia sessió amb Ethereum** per continuar.',
+
+    signInWithEthereumScreen_signedOut_heading: 'Inicia sessió amb Ethereum',
+    signInWithEthereumScreen_signedOut_h1: "Aquesta aplicació vol verificar que ets el propietari d'aquesta cartera.",
+    signInWithEthereumScreen_signedOut_p: `Signa la sol·licitud de missatge en la teva cartera per continuar.`,
+    signInWithEthereumScreen_signedOut_button: 'Inicia sessió',
+
+    signInWithEthereumScreen_signedIn_heading: 'Sessió iniciada amb Ethereum',
+    signInWithEthereumScreen_signedIn_h1: "T'has verificat correctament com a propietari d'aquesta cartera.",
+    signInWithEthereumScreen_signedIn_p: `Si tanques la sessió, hauràs de tornar a autenticar-te més endavant.`,
+    signInWithEthereumScreen_signedIn_button: 'Tanca sessió',
+};
+
+export default caAD;


### PR DESCRIPTION
This commit introduces support for the Catalan language as spoken in Andorra and Catalonia (ca_AD).

Changes include:
- Added new language files for ca_AD compatibility.

With these changes, users can now select ca_AD from the language options.