### PR TITLE
Move onSignIn and onSignOut type definitions in the SIWEConfig

### DIFF
--- a/packages/connectkit/src/siwe/SIWEContext.tsx
+++ b/packages/connectkit/src/siwe/SIWEContext.tsx
@@ -37,6 +37,8 @@ export type SIWEConfig = {
   signOutOnDisconnect?: boolean;
   signOutOnAccountChange?: boolean;
   signOutOnNetworkChange?: boolean;
+  onSignIn?: (session?: SIWESession) => void;
+  onSignOut?: () => void;
 };
 
 export type SIWEContextValue = Required<SIWEConfig> & {

--- a/packages/connectkit/src/siwe/SIWEProvider.tsx
+++ b/packages/connectkit/src/siwe/SIWEProvider.tsx
@@ -13,8 +13,6 @@ import {
 
 type Props = SIWEConfig & {
   children: ReactNode;
-  onSignIn?: (data?: SIWESession) => void;
-  onSignOut?: () => void;
 };
 
 export const SIWE_NONCE_QUERY_KEY = 'ckSiweNonce';
@@ -28,8 +26,8 @@ export const SIWEProvider = ({
   signOutOnDisconnect = true,
   signOutOnAccountChange = true,
   signOutOnNetworkChange = true,
-  onSignIn,
-  onSignOut,
+  onSignIn = () => {},
+  onSignOut = () => {},
   ...siweConfig
 }: Props) => {
   const [status, setStatus] = useState<StatusState>(StatusState.READY);
@@ -178,6 +176,8 @@ export const SIWEProvider = ({
         signOutOnDisconnect,
         signOutOnAccountChange,
         signOutOnNetworkChange,
+        onSignIn,
+        onSignOut,
         ...siweConfig,
         nonce,
         session,


### PR DESCRIPTION
Move onSignIn and onSignOut type definitions in the SIWEConfig.
Use empty functions as default.