### PR TITLE
Fix: Prevent Family Wallet Connection Pop-up from Being Blocked

### DIFF
--- a/packages/connectkit/src/components/Pages/Connectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/Connectors/index.tsx
@@ -28,10 +28,13 @@ import {
 import { OrDivider } from '../../Common/Modal';
 import { FamilyAccountsButton } from '../../Common/FamilyAccountsButton';
 import { isFamily } from '../../../utils/wallets';
+import { states } from '../../ConnectModal/ConnectWithInjector';
+import { useConnect } from '../../../hooks/useConnect';
 
 const Wallets: React.FC = () => {
   const context = useContext();
   const locales = useLocales({});
+  const { connect } = useConnect();
 
   const isMobile = useIsMobile();
   const familyConnector = useFamilyConnector();
@@ -49,11 +52,17 @@ const Wallets: React.FC = () => {
           <>
             <FamilyAccountsButton
               onClick={() => {
+                // Determine the correct connector to use
+                let connector;
                 if (familyConnector && isFamily()) {
-                  context.setConnector(familyConnector);
+                  connector = familyConnector;
                 } else {
-                  context.setConnector(familyAccountsConnector);
+                  connector = familyAccountsConnector;
                 }
+                context.setConnector(connector);
+                // connect directly
+                connect({ connector });
+                // Set route for UI updates
                 context.setRoute(routes.CONNECT);
               }}
             />


### PR DESCRIPTION
This PR addresses an issue where the **Family Wallet connection pop-up** was being blocked by browsers due to it not being triggered by a direct user interaction.

### Changes Made

- Improved the connection flow to ensure pop-ups are triggered properly

### 🎥 Demo


https://github.com/user-attachments/assets/331be9f4-489a-4dd8-aea9-f109fae3f079

A video has been created showing the difference between:
- ❌ The old flow — where pop-ups could be blocked
- ✅ The new flow — where the connection works seamlessly

### 🔍 Testing

Tested across:
- **Chrome**
- **Safari**
