### PR TITLE
fix: deduplicate injected connector when EIP-6963 wallet is detected

### DIFF
--- a/packages/connectkit/src/wallets/useWallets.tsx
+++ b/packages/connectkit/src/wallets/useWallets.tsx
@@ -77,6 +77,20 @@ export const useWallets = (): WalletProps[] => {
         (wallet, index, self) =>
           self.findIndex((w) => w.id === wallet.id) === index
       )
+      // If an EIP-6963 injected connector is present (type 'injected' with a
+      // non-generic id), remove the generic 'injected' connector to avoid
+      // showing duplicate entries for the same browser-extension wallet.
+      .filter(
+        (wallet, _index, self) =>
+          !(
+            wallet.id === 'injected' &&
+            self.some(
+              (w) =>
+                w.id !== 'injected' &&
+                isInjectedConnector(w.connector.type)
+            )
+          )
+      )
       // Replace walletConnect's name with the one from options
       .map((wallet) => {
         if (wallet.id === 'walletConnect') {


### PR DESCRIPTION
## Summary
- When a user configures an `injected()` connector (e.g. Bitget Wallet) and the wallet's browser extension is also installed, both the generic injected connector (`id: 'injected'`) and the EIP-6963 auto-detected connector (`id: 'com.bitget.wallet'`) appear in the modal as duplicates
- Added a dedup filter that removes the generic `injected` connector when a richer EIP-6963 connector is already present, following the same pattern used for Coinbase Wallet and MetaMask dedup

**File:** `packages/connectkit/src/wallets/useWallets.tsx`

Fixes #430

## Test plan
- [ ] Configure an injected connector for a wallet that also has a browser extension
- [ ] Verify only one entry appears in the modal (the EIP-6963 one with proper icon/name)
- [ ] Verify wallets without extensions still appear normally