### PR TITLE
fix: add Base to default chains so its icon renders out of the box

### DIFF
--- a/packages/connectkit/src/defaultConfig.ts
+++ b/packages/connectkit/src/defaultConfig.ts
@@ -1,6 +1,6 @@
 import { http } from 'wagmi';
 import { type CreateConfigParameters } from '@wagmi/core';
-import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
+import { mainnet, polygon, optimism, arbitrum, base } from 'wagmi/chains';
 import { CoinbaseWalletParameters } from 'wagmi/connectors';
 import { EthereumProviderOptions as AaveAccountOptions } from '@aave/account';
 
@@ -34,7 +34,7 @@ const defaultConfig = ({
   appUrl,
   walletConnectProjectId,
   coinbaseWalletPreference,
-  chains = [mainnet, polygon, optimism, arbitrum],
+  chains = [mainnet, polygon, optimism, arbitrum, base],
   client,
   enableAaveAccount = true,
   aaveAccountOptions,

--- a/packages/connectkit/src/defaultTransports.ts
+++ b/packages/connectkit/src/defaultTransports.ts
@@ -8,7 +8,7 @@
 
 import { fallback, http, webSocket } from 'wagmi';
 import { type CreateConfigParameters } from '@wagmi/core';
-import { type Chain, mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
+import { type Chain, mainnet, polygon, optimism, arbitrum, base } from 'wagmi/chains';
 import { type HttpTransport, type WebSocketTransport } from 'viem';
 
 import { chainConfigs } from './constants/chainConfigs';
@@ -48,7 +48,7 @@ type GetDefaultTransportsProps = {
 };
 
 export const getDefaultTransports = ({
-  chains = [mainnet, polygon, optimism, arbitrum],
+  chains = [mainnet, polygon, optimism, arbitrum, base],
   alchemyId,
   infuraId,
 }: GetDefaultTransportsProps): CreateConfigParameters['transports'] => {


### PR DESCRIPTION
## Summary
- Base (chain ID 8453) had its icon SVG added in #418 but was not included in the default chains array
- The chain icon mapping was never triggered because Base wasn't in the list
- Add `base` to the default chains in `defaultConfig.ts` and `defaultTransports.ts`

**Files:**
- `packages/connectkit/src/defaultConfig.ts`
- `packages/connectkit/src/defaultTransports.ts`

Fixes #438

## Test plan
- [ ] Base chain icon renders in the network selector without custom config
- [ ] Other chain icons (Arbitrum, Mainnet, Polygon, Optimism) still render
- [ ] Default config connects to Base correctly