### PR TITLE
fix: disable storage on ENS fallback config

### DIFF
--- a/packages/connectkit/src/hooks/useEnsFallbackConfig.ts
+++ b/packages/connectkit/src/hooks/useEnsFallbackConfig.ts
@@ -8,6 +8,7 @@ const ensFallbackConfig = createConfig({
   transports: {
     [mainnet.id]: http(),
   },
+  storage: null,
 });
 
 export function useEnsFallbackConfig(): Config | undefined {


### PR DESCRIPTION
The internal ENS fallback config creates a separate Wagmi instance that writes to localStorage under the default "wagmi.store" key. When the host app uses a custom storage key, both keys coexist and the fallback config overrides the user's chain selection on page reload.

Setting `storage: null` on the fallback config prevents it from persisting any state, which is correct since it only exists for read-only ENS resolution on mainnet.

Fixes #479