### PR TITLE
fix: narval connector sdk can be used

### DIFF
--- a/packages/connectkit/src/utils/index.ts
+++ b/packages/connectkit/src/utils/index.ts
@@ -89,6 +89,9 @@ export const isMetaMaskConnector = (connectorId?: string) =>
 export const isCoinbaseWalletConnector = (connectorId?: string) =>
   connectorId === 'coinbaseWalletSDK';
 
+export const isNarvalConnector = (connectorId?: string) =>
+  !!connectorId?.startsWith('narval-');
+
 export const isLedgerConnector = (connectorId?: string) =>
   connectorId === 'ledger';
 

--- a/packages/connectkit/src/wallets/useWallets.tsx
+++ b/packages/connectkit/src/wallets/useWallets.tsx
@@ -3,7 +3,11 @@ import { Connector } from 'wagmi';
 import { useConnectors } from '../hooks/useConnectors';
 import { walletConfigs, WalletConfigProps } from './walletConfigs';
 import { useContext } from '../components/ConnectKit';
-import { isCoinbaseWalletConnector, isInjectedConnector } from '../utils';
+import {
+  isCoinbaseWalletConnector,
+  isInjectedConnector,
+  isNarvalConnector,
+} from '../utils';
 
 export type WalletProps = {
   id: string;
@@ -48,7 +52,8 @@ export const useWallets = (): WalletProps[] => {
       isInstalled:
         connector.type === 'mock' ||
         (connector.type === 'injected' && connector.id !== 'metaMask') ||
-        isCoinbaseWalletConnector(connector.id), // always run coinbase wallet SDK
+        isCoinbaseWalletConnector(connector.id) || // always run coinbase wallet SDK
+        isNarvalConnector(connector.id), // always run narval connect sdk if provided
     };
 
     if (walletId) {


### PR DESCRIPTION
## Summary
Updates isInstalled check to treat narval connector as installed.
This fixes a problem where narval sdk either pretends `type: 'injected'`, which always orders it above default connectors (client cannot change their ordering), or the `type: 'narval'` orders correctly but display "install extension" error when used.

This is a pre-requisite to a PR on Aave: https://github.com/aave/interface/pull/2998
