### PR TITLE
fix: don't crash when ENS name fails ENSIP-15 normalization

### DIFF
--- a/packages/connectkit/src/components/Common/Avatar/index.tsx
+++ b/packages/connectkit/src/components/Common/Avatar/index.tsx
@@ -11,6 +11,16 @@ import { useEnsFallbackConfig } from '../../../hooks/useEnsFallbackConfig';
 
 type Hash = `0x${string}`;
 
+// Not every reverse-resolved primary ENS name is normalizable (ENSIP-15
+// disallows some characters); throwing here would crash the consuming app.
+const safeNormalize = (name: string): string => {
+  try {
+    return normalize(name);
+  } catch {
+    return '';
+  }
+};
+
 export type CustomAvatarProps = {
   address?: Hash | undefined;
   ensName?: string | undefined;
@@ -44,7 +54,7 @@ const Avatar: React.FC<{
   });
   const { data: ensAvatar } = useEnsAvatar({
     chainId: 1,
-    name: normalize(ensName ?? ''),
+    name: safeNormalize(ensName ?? ''),
     config: ensFallbackConfig,
   });
 


### PR DESCRIPTION
Avatar calls normalize(ensName ?? '') during render. If the connected wallet's reverse-resolved primary ENS name contains disallowed characters (real example: the zalgo-text name on 0xfb3c7eb936cAA12B5A884d612393969A557d4307), normalize throws and the consuming app's whole React tree unmounts with a white screen.

This guards the call and falls back to '', matching the existing behavior when no name resolves: the avatar query stays disabled and the fallback avatar renders. The raw name still displays.

Hit this in production on app.aave.com; we are shipping it as a patch-package patch in the meantime (https://github.com/aave/interface/pull/3076).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/family/codesmith/connectkit/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787240125&installation_model_id=426225&pr_number=513&repository=family%2Fconnectkit&return_to=https%3A%2F%2Fgithub.com%2Ffamily%2Fconnectkit%2Fpull%2F513&signature=25cd57e02d2f82db1b2dab5565e4528ba8701e2b3e79b662e2f3c09b86491f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->